### PR TITLE
Fix formula editor MathLive latex normalization

### DIFF
--- a/projects/ngx-coding-components/src/lib/rich-text-editor/extensions/iqb-math-formula.ts
+++ b/projects/ngx-coding-components/src/lib/rich-text-editor/extensions/iqb-math-formula.ts
@@ -1,6 +1,7 @@
 import { mergeAttributes, Node } from '@tiptap/core';
 import { Plugin } from '@tiptap/pm/state';
 import katex from 'katex';
+import { normalizeFormulaLatex } from '../formula-latex.utils';
 
 const renderFormula = (latex: string): string => katex.renderToString(latex, {
   output: 'mathml',
@@ -43,7 +44,7 @@ const IqbMathFormula = Node.create({
   },
 
   renderHTML({ HTMLAttributes }) {
-    const latex = (HTMLAttributes['latex'] || '').toString();
+    const latex = normalizeFormulaLatex((HTMLAttributes['latex'] || '').toString());
     const attributesWithoutLatex = { ...HTMLAttributes };
     delete attributesWithoutLatex['latex'];
     const content = document.createElement('span');
@@ -62,7 +63,7 @@ const IqbMathFormula = Node.create({
       insertIqbMathFormula: latex => ({ commands }) => commands.insertContent({
         type: this.name,
         attrs: {
-          latex: latex.trim()
+          latex: normalizeFormulaLatex(latex)
         }
       })
     };

--- a/projects/ngx-coding-components/src/lib/rich-text-editor/formula-edit-dialog.component.ts
+++ b/projects/ngx-coding-components/src/lib/rich-text-editor/formula-edit-dialog.component.ts
@@ -18,9 +18,11 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { TranslateModule } from '@ngx-translate/core';
 import '@iqb/mathlive';
 import katex from 'katex';
+import { normalizeFormulaLatex } from './formula-latex.utils';
 
 type MathfieldElementLike = HTMLElement & {
   value: string;
+  getValue?: (format?: 'latex') => string;
   focus: () => void;
 };
 
@@ -94,7 +96,7 @@ export class FormulaEditDialogComponent implements AfterViewInit {
     @Inject(MAT_DIALOG_DATA) public data: FormulaEditDialogData,
     private sanitizer: DomSanitizer
   ) {
-    this.latex = data.latex || '';
+    this.latex = normalizeFormulaLatex(data.latex || '');
     this.updatePreview();
   }
 
@@ -107,18 +109,21 @@ export class FormulaEditDialogComponent implements AfterViewInit {
 
   onMathInput(event: Event): void {
     const source = event.target as MathfieldElementLike;
-    this.latex = source.value || '';
+    const rawLatex = source.getValue?.('latex') ?? source.value ?? '';
+    this.latex = normalizeFormulaLatex(rawLatex);
     this.updatePreview();
   }
 
   private updatePreview(): void {
-    if (!this.latex.trim()) {
+    const normalizedLatex = normalizeFormulaLatex(this.latex);
+
+    if (!normalizedLatex) {
       this.renderedFormula = null;
       return;
     }
 
     this.renderedFormula = this.sanitizer.bypassSecurityTrustHtml(
-      katex.renderToString(this.latex, {
+      katex.renderToString(normalizedLatex, {
         output: 'mathml',
         throwOnError: false,
         strict: 'ignore'

--- a/projects/ngx-coding-components/src/lib/rich-text-editor/formula-latex.utils.spec.ts
+++ b/projects/ngx-coding-components/src/lib/rich-text-editor/formula-latex.utils.spec.ts
@@ -1,0 +1,15 @@
+import { normalizeFormulaLatex } from './formula-latex.utils';
+
+describe('normalizeFormulaLatex', () => {
+  it('should convert MathLive exponential e to KaTeX-compatible latex', () => {
+    expect(normalizeFormulaLatex('\\exponentialE')).toBe('\\mathrm{e}');
+  });
+
+  it('should remove empty MathLive placeholders from limit expressions', () => {
+    expect(normalizeFormulaLatex('\\lim_{\\placeholder{}} x = y')).toBe('\\lim x = y');
+  });
+
+  it('should keep placeholder content while removing the wrapper', () => {
+    expect(normalizeFormulaLatex('\\placeholder[id]{n}')).toBe('n');
+  });
+});

--- a/projects/ngx-coding-components/src/lib/rich-text-editor/formula-latex.utils.ts
+++ b/projects/ngx-coding-components/src/lib/rich-text-editor/formula-latex.utils.ts
@@ -1,0 +1,9 @@
+const PLACEHOLDER_REGEX = /\\placeholder(?:\[[^\]]*])?\{([^{}]*)}/g;
+const EMPTY_SCRIPT_REGEX = /([_^])\{\s*}/g;
+const EXPONENTIAL_E_REGEX = /\\exponentialE\b/g;
+
+export const normalizeFormulaLatex = (latex: string): string => latex
+  .trim()
+  .replace(PLACEHOLDER_REGEX, '$1')
+  .replace(EMPTY_SCRIPT_REGEX, '')
+  .replace(EXPONENTIAL_E_REGEX, '\\mathrm{e}');

--- a/projects/ngx-coding-components/src/lib/rich-text-editor/manual-instruction-math.ts
+++ b/projects/ngx-coding-components/src/lib/rich-text-editor/manual-instruction-math.ts
@@ -1,9 +1,10 @@
 import katex from 'katex';
+import { normalizeFormulaLatex } from './formula-latex.utils';
 
 const FORMULA_TOKEN_REGEX = /\[\[iqb-math:([\s\S]*?)]]/g;
 
 const renderFormula = (latex: string): string => {
-  const formula = latex.trim();
+  const formula = normalizeFormulaLatex(latex);
   if (!formula) return '';
   return katex.renderToString(formula, {
     output: 'mathml',
@@ -26,7 +27,7 @@ export const renderManualInstructionMath = (html: string): string => {
   const withTokensRendered = html.replace(
     FORMULA_TOKEN_REGEX,
     (_, encodedFormula: string) => {
-      const latex = decodeTokenFormula(encodedFormula);
+      const latex = normalizeFormulaLatex(decodeTokenFormula(encodedFormula));
       const escapedLatex = latex.replace(/"/g, '&quot;');
       return `<span class="iqb-math-formula" data-latex="${escapedLatex}">${renderFormula(latex)}</span>`;
     }

--- a/projects/ngx-coding-components/src/lib/rich-text-editor/rich-text-editor.component.spec.ts
+++ b/projects/ngx-coding-components/src/lib/rich-text-editor/rich-text-editor.component.spec.ts
@@ -267,4 +267,16 @@ describe('RichTextEditorComponent', () => {
     expect(chain.insertIqbMathFormula).toHaveBeenCalledWith('\\frac{1}{2}');
     expect(chain.run).toHaveBeenCalled();
   });
+
+  it('insertFormula should normalize MathLive latex before insertion', () => {
+    const { component, chain, matDialog } = createComponentWithFakeEditor();
+    (matDialog.open as jasmine.Spy).and.returnValue({
+      afterClosed: () => of('\\exponentialE + \\lim_{\\placeholder{}} x')
+    });
+
+    component.insertFormula();
+
+    expect(chain.insertIqbMathFormula).toHaveBeenCalledWith('\\mathrm{e} + \\lim x');
+    expect(chain.run).toHaveBeenCalled();
+  });
 });

--- a/projects/ngx-coding-components/src/lib/rich-text-editor/rich-text-editor.component.ts
+++ b/projects/ngx-coding-components/src/lib/rich-text-editor/rich-text-editor.component.ts
@@ -42,6 +42,7 @@ import { FileService } from '../services/file.service';
 import { ComboButtonComponent } from './combo-button.component';
 import { FormulaEditDialogComponent } from './formula-edit-dialog.component';
 import IqbMathFormula from './extensions/iqb-math-formula';
+import { normalizeFormulaLatex } from './formula-latex.utils';
 import { renderManualInstructionMath } from './manual-instruction-math';
 
 @Component({
@@ -260,9 +261,9 @@ export class RichTextEditorComponent implements AfterViewInit, OnChanges {
     });
 
     dialogRef.afterClosed().subscribe(dialogResult => {
-      if (typeof dialogResult === 'string' && dialogResult.trim()) {
+      if (typeof dialogResult === 'string' && normalizeFormulaLatex(dialogResult)) {
         this.editor.chain()
-          .insertIqbMathFormula(dialogResult.trim())
+          .insertIqbMathFormula(normalizeFormulaLatex(dialogResult))
           .focus()
           .run();
       }
@@ -285,9 +286,9 @@ export class RichTextEditorComponent implements AfterViewInit, OnChanges {
     });
 
     dialogRef.afterClosed().subscribe(dialogResult => {
-      if (typeof dialogResult === 'string' && dialogResult.trim()) {
+      if (typeof dialogResult === 'string' && normalizeFormulaLatex(dialogResult)) {
         const transaction = this.editor.state.tr.setNodeMarkup(position, null, {
-          latex: dialogResult.trim()
+          latex: normalizeFormulaLatex(dialogResult)
         });
         this.editor.view.dispatch(transaction);
       }


### PR DESCRIPTION
## Summary
- normalize MathLive-specific LaTeX before previewing and saving formulas
- remove empty placeholder scripts from formulas so `lim` without a limit no longer renders a placeholder
- cover the normalization with focused Rich Text Editor tests

## Testing
- npm run test:cc -- --include='projects/ngx-coding-components/src/lib/rich-text-editor/**/*.spec.ts'
- npx eslint /Users/julian/iqb-dev/coding-components/projects/ngx-coding-components/src/lib/rich-text-editor/formula-latex.utils.ts /Users/julian/iqb-dev/coding-components/projects/ngx-coding-components/src/lib/rich-text-editor/formula-latex.utils.spec.ts /Users/julian/iqb-dev/coding-components/projects/ngx-coding-components/src/lib/rich-text-editor/formula-edit-dialog.component.ts /Users/julian/iqb-dev/coding-components/projects/ngx-coding-components/src/lib/rich-text-editor/manual-instruction-math.ts /Users/julian/iqb-dev/coding-components/projects/ngx-coding-components/src/lib/rich-text-editor/extensions/iqb-math-formula.ts /Users/julian/iqb-dev/coding-components/projects/ngx-coding-components/src/lib/rich-text-editor/rich-text-editor.component.ts /Users/julian/iqb-dev/coding-components/projects/ngx-coding-components/src/lib/rich-text-editor/rich-text-editor.component.spec.ts

Closes #159
