### PR TITLE
Add manual instructions for automatic residual solver codes

### DIFF
--- a/projects/ngx-coding-components/src/lib/services/schemer-code-ops.spec.ts
+++ b/projects/ngx-coding-components/src/lib/services/schemer-code-ops.spec.ts
@@ -1,5 +1,6 @@
 import { CodeData, CodeType } from '@iqbspecs/coding-scheme/coding-scheme.interface';
 import {
+  DEFAULT_RESIDUAL_MANUAL_INSTRUCTION,
   addCode,
   canEdit,
   canPasteSingleCodeInto,
@@ -123,7 +124,16 @@ describe('schemer-code-ops', () => {
       const list: CodeData[] = [];
       const created = addCode(list, 'RESIDUAL', 'RW_MAXIMAL', orderOfCodeTypes) as CodeData;
       expect(created.id).toBe(0);
+      expect(created.manualInstruction).toBe(DEFAULT_RESIDUAL_MANUAL_INSTRUCTION);
       expect(list.length).toBe(1);
+    });
+
+    it('should create RESIDUAL_AUTO with default manualInstruction', () => {
+      const list: CodeData[] = [];
+      const created = addCode(list, 'RESIDUAL_AUTO', 'RW_MAXIMAL', orderOfCodeTypes) as CodeData;
+
+      expect(created.type).toBe('RESIDUAL_AUTO');
+      expect(created.manualInstruction).toBe(DEFAULT_RESIDUAL_MANUAL_INSTRUCTION);
     });
 
     it('should create INTENDED_INCOMPLETE with id 0 and empty manualInstruction', () => {

--- a/projects/ngx-coding-components/src/lib/services/schemer-code-ops.ts
+++ b/projects/ngx-coding-components/src/lib/services/schemer-code-ops.ts
@@ -14,6 +14,15 @@ const residualTypes: CodeType[] = [
   'INTENDED_INCOMPLETE'
 ];
 
+export const DEFAULT_RESIDUAL_MANUAL_INSTRUCTION =
+  '<p style="padding-left: 0; text-indent: 0; margin-bottom: 0; margin-top: 0">Alle anderen Antworten</p>';
+
+export const ensureResidualAutoManualInstruction = (code: CodeData): boolean => {
+  if (code.type !== 'RESIDUAL_AUTO' || code.manualInstruction) return false;
+  code.manualInstruction = DEFAULT_RESIDUAL_MANUAL_INSTRUCTION;
+  return true;
+};
+
 export const canEdit = (userRole: UserRoleType): boolean => ['RW_MINIMAL', 'RW_MAXIMAL'].includes(userRole);
 
 export const copySingleCode = (code: CodeData | null | undefined): CodeData | null => {
@@ -72,10 +81,7 @@ export const addCode = (
       score: 0,
       ruleSetOperatorAnd: true,
       ruleSets: [],
-      manualInstruction:
-        codeType === 'RESIDUAL_AUTO' ?
-          '' :
-          '<p style="padding-left: 0; text-indent: 0; margin-bottom: 0; margin-top: 0">Alle anderen Antworten</p>'
+      manualInstruction: DEFAULT_RESIDUAL_MANUAL_INSTRUCTION
     };
 
     codeList.push(newCode);

--- a/projects/ngx-coding-components/src/lib/translations/de.json
+++ b/projects/ngx-coding-components/src/lib/translations/de.json
@@ -274,7 +274,7 @@
       "title": "Instruktionen für manuelles Kodieren",
       "prompt-edit": "Instruktionen für manuelles Kodieren ändern",
       "wipe": "Instruktionen komplett löschen",
-      "error-residual-auto": "Wenn ein automatischer Code für 'Alle anderen Antworten' definiert ist, werden manuelle Instruktionen nie genutzt.",
+      "error-residual-auto": "Im normalen automatischen Fall für 'Alle anderen Antworten' werden manuelle Instruktionen nicht genutzt.",
       "error-intended-incomplete": "Wenn ein automatischer Code für 'Absichtlich unvollständig' definiert ist, werden manuelle Instruktionen nie genutzt."
     },
     "coding": {

--- a/projects/ngx-coding-components/src/lib/var-coding/code-instruction.component.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/code-instruction.component.ts
@@ -36,7 +36,11 @@ import { renderManualInstructionMath } from '../rich-text-editor/manual-instruct
             >
               <mat-icon> edit </mat-icon>
             </button>
-            @if ((hasResidualAutoCode) && code.manualInstruction) {
+            @if (
+              (hasResidualAutoCode) &&
+              !suppressResidualAutoWarning &&
+              code.manualInstruction
+            ) {
             <mat-icon
               [style.color]="'red'"
               [matTooltip]="
@@ -107,6 +111,7 @@ export class CodeInstructionComponent {
   @Input() userRole: UserRoleType = 'RO';
   @Input() hasIntendedIncompleteCode = false;
   @Input() hasResidualAutoCode = false;
+  @Input() suppressResidualAutoWarning = false;
 
   constructor(
     private sanitizer: DomSanitizer,

--- a/projects/ngx-coding-components/src/lib/var-coding/single-code.component.html
+++ b/projects/ngx-coding-components/src/lib/var-coding/single-code.component.html
@@ -46,7 +46,7 @@
           codeType === 'RESIDUAL') &&
         (hasResidualAutoCode || hasIntendedIncompleteAutoCode)
       "
-      (click)="code.type = codeType; setCodeChanged()"
+      (click)="setCodeType(codeType)"
     >
       @if (codeType === 'FULL_CREDIT') {
       <mat-icon style="color: limegreen">done_all</mat-icon>
@@ -182,32 +182,32 @@
       (codeRulesChanged)="setCodeChanged()"
     >
     </code-rules>
-    } @else if (codeModel === 'MANUAL_ONLY' && (code.type !== 'RESIDUAL_AUTO' &&
-    code.type !== 'INTENDED_INCOMPLETE')) {
+    } @else if (codeModel === 'MANUAL_ONLY' && showManualOnlyInstruction()) {
     <code-instruction
       [code]="code"
       (codeDataChanged)="setCodeChanged()"
       [userRole]="schemerService.userRole"
       [hasResidualAutoCode]="hasResidualAutoCode"
       [hasIntendedIncompleteCode]="hasIntendedIncompleteAutoCode"
+      [suppressResidualAutoWarning]="suppressResidualAutoWarning()"
     >
     </code-instruction>
     }
   </div>
-  @if ((codeModel ?? 'NONE') === 'NONE' || codeModel === 'MANUAL_AND_RULES') { @if (code.type && (code.type ===
-  'RESIDUAL_AUTO' || code.type === 'INTENDED_INCOMPLETE') &&
-  !code.manualInstruction) {
-  <div class="fx-flex-fill"></div>
-  } @else {
+  @if ((codeModel ?? 'NONE') === 'NONE' || codeModel === 'MANUAL_AND_RULES') {
+  @if (showSideInstruction()) {
   <code-instruction
     [code]="code"
     (codeDataChanged)="setCodeChanged()"
     [userRole]="schemerService.userRole"
     [hasResidualAutoCode]="hasResidualAutoCode"
     [hasIntendedIncompleteCode]="hasIntendedIncompleteAutoCode"
+    [suppressResidualAutoWarning]="suppressResidualAutoWarning()"
     class="fx-flex-fill"
   >
   </code-instruction>
+  } @else {
+  <div class="fx-flex-fill"></div>
   } }
   <button
     mat-icon-button

--- a/projects/ngx-coding-components/src/lib/var-coding/single-code.component.spec.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/single-code.component.spec.ts
@@ -1,0 +1,67 @@
+import { CodeData } from '@iqbspecs/coding-scheme/coding-scheme.interface';
+import { DEFAULT_RESIDUAL_MANUAL_INSTRUCTION } from '../services/schemer-code-ops';
+import { SchemerService } from '../services/schemer.service';
+import { SingleCodeComponent } from './single-code.component';
+
+describe('SingleCodeComponent', () => {
+  let component: SingleCodeComponent;
+
+  beforeEach(() => {
+    component = new SingleCodeComponent({
+      userRole: 'RW_MAXIMAL',
+      copySingleCode: jasmine.createSpy('copySingleCode'),
+      deleteCode: jasmine.createSpy('deleteCode')
+    } as unknown as SchemerService);
+  });
+
+  it('setCodeType should add default manualInstruction for RESIDUAL_AUTO', () => {
+    component.code = {
+      id: 1,
+      type: 'FULL_CREDIT',
+      label: '',
+      score: 1,
+      manualInstruction: ''
+    } as unknown as CodeData;
+    const emitSpy = spyOn(component.codeDataChanged, 'emit');
+
+    component.setCodeType('RESIDUAL_AUTO');
+
+    expect(component.code.type).toBe('RESIDUAL_AUTO');
+    expect(component.code.manualInstruction).toBe(DEFAULT_RESIDUAL_MANUAL_INSTRUCTION);
+    expect(emitSpy).toHaveBeenCalledWith(component.code);
+  });
+
+  it('setCodeType should not overwrite existing manualInstruction', () => {
+    component.code = {
+      id: 1,
+      type: 'FULL_CREDIT',
+      label: '',
+      score: 1,
+      manualInstruction: '<p>custom</p>'
+    } as unknown as CodeData;
+
+    component.setCodeType('RESIDUAL_AUTO');
+
+    expect(component.code.manualInstruction).toBe('<p>custom</p>');
+  });
+
+  it('should show RESIDUAL_AUTO manual instructions only for SOLVER codings', () => {
+    component.code = {
+      id: 0,
+      type: 'RESIDUAL_AUTO',
+      label: '',
+      score: 0,
+      manualInstruction: DEFAULT_RESIDUAL_MANUAL_INSTRUCTION
+    } as unknown as CodeData;
+
+    component.sourceType = 'BASE';
+    expect(component.showManualOnlyInstruction()).toBeFalse();
+    expect(component.showSideInstruction()).toBeFalse();
+    expect(component.suppressResidualAutoWarning()).toBeFalse();
+
+    component.sourceType = 'SOLVER';
+    expect(component.showManualOnlyInstruction()).toBeTrue();
+    expect(component.showSideInstruction()).toBeTrue();
+    expect(component.suppressResidualAutoWarning()).toBeTrue();
+  });
+});

--- a/projects/ngx-coding-components/src/lib/var-coding/single-code.component.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/single-code.component.ts
@@ -12,10 +12,13 @@ import { MatDivider } from '@angular/material/divider';
 import { MatMenu, MatMenuItem, MatMenuTrigger } from '@angular/material/menu';
 import {
   CodeData,
-  CodeModelType
+  CodeModelType,
+  CodeType,
+  VariableCodingData
 } from '@iqbspecs/coding-scheme/coding-scheme.interface';
 import { VariableInfo } from '@iqbspecs/variable-info/variable-info.interface';
 import { SchemerService } from '../services/schemer.service';
+import { ensureResidualAutoManualInstruction } from '../services/schemer-code-ops';
 import { CodeRulesComponent } from './code-rules/code-rules.component';
 import { CodeInstructionComponent } from './code-instruction.component';
 
@@ -74,6 +77,7 @@ export class SingleCodeComponent {
   @Input() fragmentMode: boolean | undefined;
   @Input() codeIndex: number | undefined;
   @Input() codeModel: CodeModelType | undefined;
+  @Input() sourceType: VariableCodingData['sourceType'] | undefined;
   @Input() hasResidualAutoCode = false;
   @Input() hasIntendedIncompleteAutoCode = false;
 
@@ -119,6 +123,35 @@ export class SingleCodeComponent {
 
   setCodeChanged() {
     this.codeDataChanged.emit(this.code);
+  }
+
+  setCodeType(codeType: CodeType) {
+    if (this.code) {
+      this.code.type = codeType;
+      ensureResidualAutoManualInstruction(this.code);
+      this.setCodeChanged();
+    }
+  }
+
+  showResidualAutoManualInstruction(): boolean {
+    return this.sourceType === 'SOLVER';
+  }
+
+  showManualOnlyInstruction(): boolean {
+    if (!this.code) return false;
+    if (this.code.type === 'RESIDUAL_AUTO') return this.showResidualAutoManualInstruction();
+    return this.code.type !== 'INTENDED_INCOMPLETE';
+  }
+
+  showSideInstruction(): boolean {
+    if (!this.code) return false;
+    if (this.code.type === 'RESIDUAL_AUTO') return this.showResidualAutoManualInstruction();
+    if (this.code.type === 'INTENDED_INCOMPLETE') return !!this.code.manualInstruction;
+    return true;
+  }
+
+  suppressResidualAutoWarning(): boolean {
+    return this.code?.type === 'RESIDUAL_AUTO' && this.showResidualAutoManualInstruction();
   }
 
   setCodeInvalid() {

--- a/projects/ngx-coding-components/src/lib/var-coding/var-coding.component.html
+++ b/projects/ngx-coding-components/src/lib/var-coding/var-coding.component.html
@@ -290,6 +290,7 @@
     [varInfo]="varInfo"
     [fragmentMode]="!!varCoding.fragmenting"
     [codeModel]="varCoding.codeModel"
+    [sourceType]="varCoding.sourceType"
     [hasResidualAutoCode]="hasResidualAutoCode"
     [hasIntendedIncompleteAutoCode]="hasIntendedIncompleteAutoCode"
     [code]="code"

--- a/projects/ngx-coding-components/src/lib/var-coding/var-coding.component.spec.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/var-coding.component.spec.ts
@@ -9,6 +9,7 @@ import { CodingFactory } from '@iqb/responses/coding-factory';
 
 import { VarCodingComponent } from './var-coding.component';
 import { SchemerService } from '../services/schemer.service';
+import { DEFAULT_RESIDUAL_MANUAL_INSTRUCTION } from '../services/schemer-code-ops';
 
 describe('VarCodingComponent', () => {
   let component: VarCodingComponent;
@@ -91,6 +92,27 @@ describe('VarCodingComponent', () => {
 
     expect(component.varCoding?.manualInstruction).toBe('');
     expect(emitSpy).toHaveBeenCalledWith(component.varCoding);
+  });
+
+  it('varCoding setter should add default manualInstruction to SOLVER RESIDUAL_AUTO codes', () => {
+    component.varCoding = {
+      id: 'v1',
+      alias: 'A',
+      sourceType: 'SOLVER',
+      codes: [
+        {
+          id: 0,
+          type: 'RESIDUAL_AUTO',
+          label: '',
+          score: 0,
+          manualInstruction: ''
+        }
+      ]
+    } as unknown as VariableCodingData;
+
+    expect(component.varCoding?.codes?.[0].manualInstruction).toBe(
+      DEFAULT_RESIDUAL_MANUAL_INSTRUCTION
+    );
   });
 
   it('smartSchemer without ctrlKey should ignore false/null/undefined dialog results', () => {

--- a/projects/ngx-coding-components/src/lib/var-coding/var-coding.component.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/var-coding.component.ts
@@ -41,6 +41,7 @@ import {
   ConfirmDialogData
 } from '../dialogs/confirm-dialog.component';
 import { SchemerService } from '../services/schemer.service';
+import { ensureResidualAutoManualInstruction } from '../services/schemer-code-ops';
 import {
   GenerateCodingDialogComponent,
   GeneratedCodingData
@@ -102,6 +103,7 @@ export class VarCodingComponent implements OnInit, OnDestroy, OnChanges {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   set varCoding(value: VariableCodingData | null) {
     this._varCoding = value;
+    this.applySolverResidualAutoInstructionDefault();
     this.updateHasResidualAutoCode();
     this.updateHasIntendedIncompleteAutoCode();
   }
@@ -163,6 +165,12 @@ export class VarCodingComponent implements OnInit, OnDestroy, OnChanges {
         c => c.type === 'INTENDED_INCOMPLETE'
       ) :
       false;
+  }
+
+  applySolverResidualAutoInstructionDefault() {
+    if (this.varCoding?.sourceType === 'SOLVER') {
+      (this.varCoding.codes || []).forEach(ensureResidualAutoManualInstruction);
+    }
   }
 
   getSanitizedText(text: string): SafeHtml {
@@ -312,6 +320,7 @@ export class VarCodingComponent implements OnInit, OnDestroy, OnChanges {
               codes: newCoding.codes
             });
 
+            this.applySolverResidualAutoInstructionDefault();
             this.updateHasResidualAutoCode();
             this.updateHasIntendedIncompleteAutoCode();
             this.varCodingChanged.emit(this.varCoding);
@@ -337,6 +346,7 @@ export class VarCodingComponent implements OnInit, OnDestroy, OnChanges {
           }
         });
       } else {
+        this.applySolverResidualAutoInstructionDefault();
         this.updateHasResidualAutoCode();
         this.updateHasIntendedIncompleteAutoCode();
         this.varCodingChanged.emit(this.varCoding);
@@ -368,6 +378,7 @@ export class VarCodingComponent implements OnInit, OnDestroy, OnChanges {
         }
       });
     } else {
+      this.applySolverResidualAutoInstructionDefault();
       this.updateHasResidualAutoCode();
       this.updateHasIntendedIncompleteAutoCode();
       this.varCodingChanged.emit(this.varCoding);
@@ -408,6 +419,7 @@ export class VarCodingComponent implements OnInit, OnDestroy, OnChanges {
             deriveSources
           });
 
+          this.applySolverResidualAutoInstructionDefault();
           this.varCodingChanged.emit(this.varCoding);
         }
       });

--- a/src/assets/de.json
+++ b/src/assets/de.json
@@ -143,7 +143,7 @@
     "has-rule-warning": {
       "autocode": "Dieser Code enthält Regeln für das automatische Kodieren.",
       "manual": "Dieser Code enthält Instruktionen für das manuelle Kodieren.",
-      "manual-else": "Dieser Code enthält Instruktionen für das manuelle Kodieren. Durch die Regel 'Alle anderen Antworten' werden aber alle Fälle automatisch abschließend kodiert."
+      "manual-else": "Dieser Code enthält Instruktionen für das manuelle Kodieren. Im normalen automatischen Fall für 'Alle anderen Antworten' werden sie nicht genutzt."
     }
   },
   "rule-set": {


### PR DESCRIPTION
## Summary

Relates to #165. This PR intentionally does not close the issue.

- adds a shared default manual instruction for residual fallback codes
- shows manual instructions for `RESIDUAL_AUTO` only on `SOLVER` variables
- backfills the default for existing SOLVER residual-auto codes when they are loaded or updated in the editor
- suppresses the generic residual-auto warning for the SOLVER-specific manual-instruction case
- adds focused tests for the default and visibility behavior

## Validation

- `npm test`
- `npm run lint` (passes with one pre-existing max-len warning in `generate-coding-dialog.component.spec.ts`)
- `npm run build_cc`
- `git diff --check`