### PR TITLE
Add security audit CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,24 @@ on:
   pull_request:
 
 jobs:
+  security-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Production dependency audit
+        run: npm audit --omit=dev --audit-level=high
+
   lint-and-test:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -369,8 +369,13 @@ Exports include:
 | `npm run build_cc` | Build the library (`ngx-coding-components`). |
 | `npm run test:cc` | Run library unit tests. |
 | `npm run lint` | Run ESLint across the project. |
+| `npm run audit:prod` | Audit production dependencies. |
 | `npm run build:elements` | Build the Web Components bundle. |
 | `npm run buildAndPack_sc` | Build and package the Verona Schemer. |
+
+## CI gates
+
+Pull requests and pushes run GitHub Actions checks for production dependency security, linting, and coverage tests. The `security-audit` job runs `npm audit --omit=dev --audit-level=high`; high or critical production dependency findings must be resolved before merging.
 
 ## Demo App
 The folder `/src` contains a demo application that showcases all components. Use `npm start` to run it locally.


### PR DESCRIPTION
## Summary
- add a dedicated `security-audit` GitHub Actions job
- fail the security gate on high or critical production dependency findings
- document the audit command and CI gate in the README

## Validation
- `npm audit --omit=dev --audit-level=high` -> `found 0 vulnerabilities`
- `npm run lint` -> exit code 0, existing max-len warning remains
- `npm run test:coverage` -> 261 + 6 specs successful

Completes #149
