### PR TITLE
Add single code paste validation

### DIFF
--- a/projects/ngx-coding-components/src/lib/services/schemer-code-ops.spec.ts
+++ b/projects/ngx-coding-components/src/lib/services/schemer-code-ops.spec.ts
@@ -7,6 +7,7 @@ import {
   copySingleCode,
   deleteCode,
   duplicateCode,
+  getPasteSingleCodeWarningKeys,
   pasteSingleCode,
   sortCodes
 } from './schemer-code-ops';
@@ -86,6 +87,109 @@ describe('schemer-code-ops', () => {
         id: 99, type: 'FULL_CREDIT', label: '', score: 1
       } as unknown as CodeData;
       expect(canPasteSingleCodeInto(copied, [], 'RW_MAXIMAL')).toBeTrue();
+    });
+  });
+
+  describe('getPasteSingleCodeWarningKeys', () => {
+    it('should warn when copied rules reference incompatible target structures', () => {
+      const copied: CodeData = {
+        id: 1,
+        type: 'FULL_CREDIT',
+        label: '',
+        score: 1,
+        ruleSets: [
+          {
+            valueArrayPos: 1,
+            ruleOperatorAnd: true,
+            rules: [
+              { method: 'MATCH', parameters: ['A'], fragment: 0 },
+              { method: 'NUMERIC_MATCH', parameters: ['1'] },
+              { method: 'IS_TRUE' }
+            ]
+          }
+        ]
+      } as unknown as CodeData;
+
+      expect(
+        getPasteSingleCodeWarningKeys(
+          copied,
+          { id: 'v1', sourceType: 'BASE', codes: [] } as unknown as never,
+          {
+            id: 'v1',
+            type: 'string',
+            multiple: false
+          } as unknown as never
+        )
+      ).toEqual([
+        'code.paste-warning.array-reference',
+        'code.paste-warning.fragment-reference',
+        'code.paste-warning.numeric-rule',
+        'code.paste-warning.boolean-rule'
+      ]);
+    });
+
+    it('should not warn when target supports copied rule references', () => {
+      const copied: CodeData = {
+        id: 1,
+        type: 'FULL_CREDIT',
+        label: '',
+        score: 1,
+        ruleSets: [
+          {
+            valueArrayPos: 0,
+            ruleOperatorAnd: true,
+            rules: [
+              { method: 'NUMERIC_MATCH', parameters: ['1'], fragment: 0 }
+            ]
+          }
+        ]
+      } as unknown as CodeData;
+
+      expect(
+        getPasteSingleCodeWarningKeys(
+          copied,
+          {
+            id: 'v1',
+            sourceType: 'BASE',
+            fragmenting: '(\\d+)',
+            codes: []
+          } as unknown as never,
+          {
+            id: 'v1',
+            type: 'integer',
+            multiple: true
+          } as unknown as never
+        )
+      ).toEqual([]);
+    });
+
+    it('should warn for NUMERIC_RANGE rules copied into non-numeric targets', () => {
+      const copied: CodeData = {
+        id: 1,
+        type: 'FULL_CREDIT',
+        label: '',
+        score: 1,
+        ruleSets: [
+          {
+            ruleOperatorAnd: true,
+            rules: [
+              { method: 'NUMERIC_RANGE', parameters: ['1', '3'] }
+            ]
+          }
+        ]
+      } as unknown as CodeData;
+
+      expect(
+        getPasteSingleCodeWarningKeys(
+          copied,
+          { id: 'v1', sourceType: 'BASE', codes: [] } as unknown as never,
+          {
+            id: 'v1',
+            type: 'string',
+            multiple: false
+          } as unknown as never
+        )
+      ).toEqual(['code.paste-warning.numeric-rule']);
     });
   });
 

--- a/projects/ngx-coding-components/src/lib/services/schemer-code-ops.ts
+++ b/projects/ngx-coding-components/src/lib/services/schemer-code-ops.ts
@@ -1,8 +1,11 @@
 import {
   CodeData,
   CodeType,
+  RuleMethod,
+  VariableCodingData,
   RuleSet
 } from '@iqbspecs/coding-scheme/coding-scheme.interface';
+import { VariableInfo } from '@iqbspecs/variable-info/variable-info.interface';
 
 export type UserRoleType = 'RO' | 'RW_MINIMAL' | 'RW_MAXIMAL';
 
@@ -13,6 +16,18 @@ const residualTypes: CodeType[] = [
   'RESIDUAL_AUTO',
   'INTENDED_INCOMPLETE'
 ];
+
+const numericRuleMethods: RuleMethod[] = [
+  'NUMERIC_MATCH',
+  'NUMERIC_RANGE',
+  'NUMERIC_FULL_RANGE',
+  'NUMERIC_MIN',
+  'NUMERIC_MORE_THAN',
+  'NUMERIC_LESS_THAN',
+  'NUMERIC_MAX'
+];
+
+const booleanRuleMethods: RuleMethod[] = ['IS_TRUE', 'IS_FALSE'];
 
 export const DEFAULT_RESIDUAL_MANUAL_INSTRUCTION =
   '<p style="padding-left: 0; text-indent: 0; margin-bottom: 0; margin-top: 0">Alle anderen Antworten</p>';
@@ -47,6 +62,46 @@ export const canPasteSingleCodeInto = (
   }
 
   return true;
+};
+
+export const getPasteSingleCodeWarningKeys = (
+  copiedCode: CodeData | null,
+  targetCoding?: VariableCodingData | null,
+  targetVarInfo?: VariableInfo
+): string[] => {
+  if (!copiedCode) return [];
+
+  const warningKeys = new Set<string>();
+  const ruleSets = copiedCode.ruleSets || [];
+  const rules = ruleSets.flatMap(ruleSet => ruleSet.rules || []);
+
+  const hasArrayReference = ruleSets.some(
+    ruleSet => typeof ruleSet.valueArrayPos !== 'undefined'
+  );
+  if (hasArrayReference && targetVarInfo && !targetVarInfo.multiple) {
+    warningKeys.add('code.paste-warning.array-reference');
+  }
+
+  const hasFragmentReference = rules.some(rule => typeof rule.fragment !== 'undefined');
+  if (hasFragmentReference && targetCoding && !targetCoding.fragmenting) {
+    warningKeys.add('code.paste-warning.fragment-reference');
+  }
+
+  const hasNumericRule = rules.some(rule => numericRuleMethods.includes(rule.method));
+  if (
+    hasNumericRule &&
+    targetVarInfo &&
+    !['integer', 'number'].includes(targetVarInfo.type)
+  ) {
+    warningKeys.add('code.paste-warning.numeric-rule');
+  }
+
+  const hasBooleanRule = rules.some(rule => booleanRuleMethods.includes(rule.method));
+  if (hasBooleanRule && targetVarInfo && targetVarInfo.type !== 'boolean') {
+    warningKeys.add('code.paste-warning.boolean-rule');
+  }
+
+  return Array.from(warningKeys);
 };
 
 export const addCode = (

--- a/projects/ngx-coding-components/src/lib/services/schemer.service.spec.ts
+++ b/projects/ngx-coding-components/src/lib/services/schemer.service.spec.ts
@@ -3,13 +3,20 @@ import {
   CodeType,
   VariableCodingData
 } from '@iqbspecs/coding-scheme/coding-scheme.interface';
+import { CodingSchemeFactory, CodingSchemeProblem } from '@iqb/responses';
 import { SchemerService } from './schemer.service';
 
 describe('SchemerService', () => {
   let service: SchemerService;
+  const copiedCodeStorageKey = 'iqb-schemer-copied-code';
 
   beforeEach(() => {
+    sessionStorage.removeItem(copiedCodeStorageKey);
     service = new SchemerService();
+  });
+
+  afterEach(() => {
+    sessionStorage.removeItem(copiedCodeStorageKey);
   });
 
   describe('checkRenamedVarAliasOk', () => {
@@ -86,6 +93,22 @@ describe('SchemerService', () => {
 
       (src as unknown as { label: string }).label = 'mutated';
       expect(service.copiedCode?.label).toBe('a');
+    });
+
+    it('should restore copied code from session storage in a fresh service instance', () => {
+      service.setUserRole('RW_MAXIMAL');
+      expect(service.copySingleCode({
+        id: 1,
+        type: 'FULL_CREDIT',
+        label: 'from-storage',
+        score: 1,
+        ruleSets: []
+      } as unknown as CodeData)).toBeTrue();
+
+      const freshService = new SchemerService();
+
+      expect(freshService.copiedCode?.label).toBe('from-storage');
+      expect(freshService.canPasteSingleCodeInto([])).toBeTrue();
     });
 
     it('canPasteSingleCodeInto should block when nothing copied or user is RO', () => {
@@ -281,6 +304,62 @@ describe('SchemerService', () => {
       const base = service.getBaseVarsList();
       expect(base.length).toBe(1);
       expect(base[0].id).toBe('v1');
+    });
+  });
+
+  describe('getCodingProblemsForVarCoding', () => {
+    it('should return validation problems for the variable id or alias', () => {
+      service.setVarList([]);
+      service.setCodingScheme({
+        variableCodings: [
+          { id: 'v1', alias: 'A', sourceType: 'BASE' } as unknown as VariableCodingData,
+          { id: 'v2', alias: 'B', sourceType: 'BASE' } as unknown as VariableCodingData
+        ]
+      } as unknown as never);
+      spyOn(CodingSchemeFactory, 'validate').and.returnValue([
+        {
+          variableId: 'A',
+          variableLabel: 'A',
+          type: 'RULE_PARAMETER_INVALID',
+          breaking: true,
+          code: '1'
+        },
+        {
+          variableId: 'v1',
+          variableLabel: 'A',
+          type: 'RULE_REGEX_INVALID',
+          breaking: true,
+          code: '2'
+        },
+        {
+          variableId: 'B',
+          variableLabel: 'B',
+          type: 'VACANT',
+          breaking: false
+        }
+      ] as CodingSchemeProblem[]);
+
+      const problems = service.getCodingProblemsForVarCoding(
+        { id: 'v1', alias: 'A', sourceType: 'BASE' } as unknown as VariableCodingData
+      );
+
+      expect(problems.map(problem => problem.type)).toEqual([
+        'RULE_PARAMETER_INVALID',
+        'RULE_REGEX_INVALID'
+      ]);
+    });
+
+    it('should return an empty list when validation fails', () => {
+      service.setCodingScheme({
+        variableCodings: [
+          { id: 'v1', alias: 'A', sourceType: 'BASE' } as unknown as VariableCodingData
+        ]
+      } as unknown as never);
+      spyOn(CodingSchemeFactory, 'validate').and.throwError('boom');
+
+      expect(service.getCodingProblemsForVarCoding(
+        { id: 'v1', alias: 'A', sourceType: 'BASE' } as unknown as VariableCodingData
+      )).toEqual([]);
     });
   });
 

--- a/projects/ngx-coding-components/src/lib/services/schemer.service.ts
+++ b/projects/ngx-coding-components/src/lib/services/schemer.service.ts
@@ -1,5 +1,9 @@
 import { Injectable, signal } from '@angular/core';
-import { CodingToTextMode } from '@iqb/responses';
+import {
+  CodingSchemeFactory,
+  CodingSchemeProblem,
+  CodingToTextMode
+} from '@iqb/responses';
 import {
   CodeData,
   CodeType,
@@ -20,12 +24,76 @@ import {
   copySingleCode as copySingleCodeOp,
   deleteCode as deleteCodeOp,
   duplicateCode as duplicateCodeOp,
+  getPasteSingleCodeWarningKeys as getPasteSingleCodeWarningKeysOp,
   pasteSingleCode as pasteSingleCodeOp,
   sortCodes as sortCodesOp
 } from './schemer-code-ops';
 
 export type UserRoleType = 'RO' | 'RW_MINIMAL' | 'RW_MAXIMAL';
 export const VARIABLE_NAME_CHECK_PATTERN = /^[a-zA-Z0-9_]{2,}$/;
+const COPIED_CODE_STORAGE_KEY = 'iqb-schemer-copied-code';
+const COPIED_CODE_STORAGE_TYPE = 'iqb-schemer-code-clipboard';
+const COPIED_CODE_STORAGE_VERSION = 1;
+
+interface StoredCopiedCode {
+  type: typeof COPIED_CODE_STORAGE_TYPE;
+  version: typeof COPIED_CODE_STORAGE_VERSION;
+  code: CodeData;
+}
+
+const getSessionStorage = (): Storage | null => {
+  try {
+    if (typeof globalThis === 'undefined' || !globalThis.sessionStorage) {
+      return null;
+    }
+    return globalThis.sessionStorage;
+  } catch {
+    return null;
+  }
+};
+
+const readCopiedCodeFromStorage = (): CodeData | null => {
+  const storage = getSessionStorage();
+  if (!storage) return null;
+
+  try {
+    const serialized = storage.getItem(COPIED_CODE_STORAGE_KEY);
+    if (!serialized) return null;
+    const stored = JSON.parse(serialized) as StoredCopiedCode;
+    if (
+      stored?.type !== COPIED_CODE_STORAGE_TYPE ||
+      stored?.version !== COPIED_CODE_STORAGE_VERSION ||
+      !stored?.code
+    ) {
+      return null;
+    }
+    return stored.code;
+  } catch {
+    return null;
+  }
+};
+
+const writeCopiedCodeToStorage = (code: CodeData | null): void => {
+  const storage = getSessionStorage();
+  if (!storage) return;
+
+  try {
+    if (!code) {
+      storage.removeItem(COPIED_CODE_STORAGE_KEY);
+      return;
+    }
+    storage.setItem(
+      COPIED_CODE_STORAGE_KEY,
+      JSON.stringify({
+        type: COPIED_CODE_STORAGE_TYPE,
+        version: COPIED_CODE_STORAGE_VERSION,
+        code
+      } satisfies StoredCopiedCode)
+    );
+  } catch {
+    // Ignore quota and privacy-mode failures; the in-memory clipboard still works.
+  }
+};
 
 @Injectable({
   providedIn: 'root'
@@ -75,11 +143,12 @@ export class SchemerService {
   }
 
   get copiedCode(): CodeData | null {
-    return this._copiedCode();
+    return this.getCopiedCode();
   }
 
   setCopiedCode(value: CodeData | null): void {
     this._copiedCode.set(value);
+    writeCopiedCodeToStorage(value);
   }
 
   get codingToTextMode(): CodingToTextMode {
@@ -187,16 +256,41 @@ export class SchemerService {
   }
 
   canPasteSingleCodeInto(codeList: CodeData[]): boolean {
-    return canPasteSingleCodeIntoOp(this.copiedCode, codeList, this.userRole);
+    return canPasteSingleCodeIntoOp(this.getCopiedCode(), codeList, this.userRole);
+  }
+
+  getPasteSingleCodeWarningKeys(
+    targetCoding?: VariableCodingData | null,
+    targetVarInfo?: VariableInfo
+  ): string[] {
+    return getPasteSingleCodeWarningKeysOp(
+      this.getCopiedCode(),
+      targetCoding,
+      targetVarInfo
+    );
   }
 
   pasteSingleCode(codeList: CodeData[]): CodeData | string {
     return pasteSingleCodeOp(
-      this.copiedCode,
+      this.getCopiedCode(),
       codeList,
       this.userRole,
       this.orderOfCodeTypes
     );
+  }
+
+  getCodingProblemsForVarCoding(varCoding: VariableCodingData | null | undefined): CodingSchemeProblem[] {
+    if (!varCoding || !this.codingScheme?.variableCodings) return [];
+
+    try {
+      const targetNames = [varCoding.id, varCoding.alias].filter(Boolean);
+      return CodingSchemeFactory.validate(
+        this.varList,
+        this.codingScheme.variableCodings
+      ).filter(problem => targetNames.includes(problem.variableId));
+    } catch {
+      return [];
+    }
   }
 
   addCode(codeList: CodeData[], codeType: CodeType): CodeData | string {
@@ -234,6 +328,15 @@ export class SchemerService {
     );
     if (maxEntries > 0 && maxEntries < varIds.length) returnValues.push('...');
     return returnValues.join(', ');
+  }
+
+  private getCopiedCode(): CodeData | null {
+    const copiedCode = this._copiedCode();
+    if (copiedCode) return copiedCode;
+
+    const storedCode = readCopiedCodeFromStorage();
+    if (storedCode) this._copiedCode.set(storedCode);
+    return storedCode;
   }
 
   getBaseVarsList() {

--- a/projects/ngx-coding-components/src/lib/translations/de.json
+++ b/projects/ngx-coding-components/src/lib/translations/de.json
@@ -369,6 +369,19 @@
       "type-not-supported": "Der Code-Typ wird nicht unterstützt.",
       "no-access": "Es fehlen für diese Aktion die Zugriffsrechte."
     },
+    "paste-warning": {
+      "title": "Code einfügen?",
+      "content": "Der kopierte Code passt möglicherweise nicht vollständig zur Zielvariable. Nach dem Einfügen sollte die Kodierung geprüft werden.",
+      "confirm": "Trotzdem einfügen",
+      "array-reference": "Der Code enthält Positionsbezüge für Mehrfachantworten.",
+      "fragment-reference": "Der Code enthält Fragmentbezüge.",
+      "numeric-rule": "Der Code enthält numerische Regeln.",
+      "boolean-rule": "Der Code enthält Wahr/Falsch-Regeln."
+    },
+    "post-paste-validation": {
+      "title": "Code eingefügt",
+      "content": "Der Code wurde eingefügt, die Zielkodierung enthält dadurch neue Validierungsprobleme:"
+    },
     "no-codes": "Derzeit sind keine Codes definiert.",
     "is-invalid": "Kein Code wird vergeben, sondern Status 'ungültig'/'INVALID'.",
     "make-invalid": "Schalte Wert ungültig",

--- a/projects/ngx-coding-components/src/lib/var-coding/var-coding.component.spec.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/var-coding.component.spec.ts
@@ -18,6 +18,8 @@ describe('VarCodingComponent', () => {
   let schemerService: SchemerService;
   let addCodeSpy: jasmine.Spy;
   let canPasteSpy: jasmine.Spy;
+  let getPasteWarningsSpy: jasmine.Spy;
+  let getCodingProblemsSpy: jasmine.Spy;
   let pasteSpy: jasmine.Spy;
   let sortCodesSpy: jasmine.Spy;
   let getAliasSpy: jasmine.Spy;
@@ -31,6 +33,8 @@ describe('VarCodingComponent', () => {
 
     addCodeSpy = jasmine.createSpy('addCode');
     canPasteSpy = jasmine.createSpy('canPasteSingleCodeInto');
+    getPasteWarningsSpy = jasmine.createSpy('getPasteSingleCodeWarningKeys').and.returnValue([]);
+    getCodingProblemsSpy = jasmine.createSpy('getCodingProblemsForVarCoding').and.returnValue([]);
     pasteSpy = jasmine.createSpy('pasteSingleCode');
     sortCodesSpy = jasmine.createSpy('sortCodes');
     getAliasSpy = jasmine.createSpy('getVariableAliasById').and.callFake((id: string) => `${id}_ALIAS`);
@@ -62,6 +66,8 @@ describe('VarCodingComponent', () => {
             codingToTextMode: 'EXTENDED',
             addCode: addCodeSpy,
             canPasteSingleCodeInto: canPasteSpy,
+            getPasteSingleCodeWarningKeys: getPasteWarningsSpy,
+            getCodingProblemsForVarCoding: getCodingProblemsSpy,
             pasteSingleCode: pasteSpy,
             sortCodes: sortCodesSpy,
             getVariableAliasById: getAliasSpy,
@@ -263,6 +269,103 @@ describe('VarCodingComponent', () => {
     component.pasteSingleCode();
     expect(dialogOpenSpy).not.toHaveBeenCalled();
     expect(emitSpy).toHaveBeenCalledWith(component.varCoding);
+  });
+
+  it('pasteSingleCode should ask for confirmation before pasting incompatible copied codes', () => {
+    component.varCoding = {
+      id: 'v1',
+      alias: 'A',
+      sourceType: 'BASE',
+      codes: []
+    } as unknown as VariableCodingData;
+    getPasteWarningsSpy.and.returnValue(['code.paste-warning.numeric-rule']);
+
+    dialogOpenSpy.and.returnValue({ afterClosed: () => of(false) });
+    component.pasteSingleCode();
+    expect(dialogOpenSpy).toHaveBeenCalled();
+    expect(pasteSpy).not.toHaveBeenCalled();
+
+    dialogOpenSpy.calls.reset();
+    pasteSpy.calls.reset();
+    dialogOpenSpy.and.returnValue({ afterClosed: () => of(undefined) });
+    component.pasteSingleCode();
+    expect(dialogOpenSpy).toHaveBeenCalled();
+    expect(pasteSpy).not.toHaveBeenCalled();
+
+    dialogOpenSpy.calls.reset();
+    pasteSpy.calls.reset();
+    dialogOpenSpy.and.returnValue({ afterClosed: () => of(true) });
+    pasteSpy.and.callFake((codeList: unknown[]) => {
+      codeList.push({
+        id: 1, type: 'FULL_CREDIT', label: '', score: 1
+      });
+      return codeList[0];
+    });
+
+    component.pasteSingleCode();
+    expect(dialogOpenSpy).toHaveBeenCalled();
+    expect(pasteSpy).toHaveBeenCalledWith(component.varCoding.codes);
+  });
+
+  it('pasteSingleCode should show validation warning when paste creates new coding problems', () => {
+    const emitSpy = spyOn(component.varCodingChanged, 'emit');
+    component.varCoding = {
+      id: 'v1',
+      alias: 'A',
+      sourceType: 'BASE',
+      codes: []
+    } as unknown as VariableCodingData;
+    getCodingProblemsSpy.and.returnValues(
+      [],
+      [{
+        variableId: 'A',
+        variableLabel: 'A',
+        type: 'RULE_PARAMETER_INVALID',
+        breaking: true,
+        code: '1'
+      }]
+    );
+    pasteSpy.and.callFake((codeList: unknown[]) => {
+      codeList.push({
+        id: 1, type: 'FULL_CREDIT', label: '', score: 1
+      });
+      return codeList[0];
+    });
+
+    component.pasteSingleCode();
+
+    expect(emitSpy).toHaveBeenCalledWith(component.varCoding);
+    expect(dialogOpenSpy).toHaveBeenCalled();
+    expect(dialogOpenSpy.calls.mostRecent().args[1].data.content).toContain(
+      'coding-problem.RULE_PARAMETER_INVALID'
+    );
+  });
+
+  it('pasteSingleCode should not show validation warning for unchanged existing coding problems', () => {
+    component.varCoding = {
+      id: 'v1',
+      alias: 'A',
+      sourceType: 'BASE',
+      codes: []
+    } as unknown as VariableCodingData;
+    const existingProblem = {
+      variableId: 'A',
+      variableLabel: 'A',
+      type: 'RULE_PARAMETER_INVALID',
+      breaking: true,
+      code: '1'
+    };
+    getCodingProblemsSpy.and.returnValues([existingProblem], [existingProblem]);
+    pasteSpy.and.callFake((codeList: unknown[]) => {
+      codeList.push({
+        id: 1, type: 'FULL_CREDIT', label: '', score: 1
+      });
+      return codeList[0];
+    });
+
+    component.pasteSingleCode();
+
+    expect(dialogOpenSpy).not.toHaveBeenCalled();
   });
 
   it('smartSchemer ctrlKey should infer code types from labels, sort codes and emit', () => {

--- a/projects/ngx-coding-components/src/lib/var-coding/var-coding.component.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/var-coding.component.ts
@@ -11,7 +11,7 @@ import {
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { MatDialog } from '@angular/material/dialog';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
-import { CodingToTextMode } from '@iqb/responses';
+import { CodingSchemeProblem, CodingToTextMode } from '@iqb/responses';
 import { BehaviorSubject, debounceTime, Subscription } from 'rxjs';
 import {
   MatCard,
@@ -366,6 +366,39 @@ export class VarCodingComponent implements OnInit, OnDestroy, OnChanges {
     if (!this.varCoding || !this.varCoding.codes) {
       return;
     }
+    const warningKeys = this.schemerService.getPasteSingleCodeWarningKeys(
+      this.varCoding,
+      this.varInfo
+    );
+    if (warningKeys.length > 0) {
+      const warningContent = [
+        this.translateService.instant('code.paste-warning.content'),
+        ...warningKeys.map(key => this.translateService.instant(key))
+      ].join(' ');
+      const dialogRef = this.confirmDialog.open(ConfirmDialogComponent, {
+        width: '500px',
+        data: <ConfirmDialogData>{
+          title: this.translateService.instant('code.paste-warning.title'),
+          content: warningContent,
+          confirmButtonLabel: this.translateService.instant('code.paste-warning.confirm'),
+          showCancel: true
+        }
+      });
+      dialogRef.afterClosed().subscribe(result => {
+        if (result === true) this.performPasteSingleCode();
+      });
+      return;
+    }
+    this.performPasteSingleCode();
+  }
+
+  private performPasteSingleCode() {
+    if (!this.varCoding || !this.varCoding.codes) {
+      return;
+    }
+    const problemsBeforePaste = this.schemerService.getCodingProblemsForVarCoding(
+      this.varCoding
+    );
     const pasteResult = this.schemerService.pasteSingleCode(
       this.varCoding.codes
     );
@@ -383,7 +416,54 @@ export class VarCodingComponent implements OnInit, OnDestroy, OnChanges {
       this.updateHasResidualAutoCode();
       this.updateHasIntendedIncompleteAutoCode();
       this.varCodingChanged.emit(this.varCoding);
+      const newProblems = VarCodingComponent.getNewCodingProblems(
+        problemsBeforePaste,
+        this.schemerService.getCodingProblemsForVarCoding(this.varCoding)
+      );
+      if (newProblems.length > 0) this.showPasteValidationWarning(newProblems);
     }
+  }
+
+  private static getNewCodingProblems(
+    beforeProblems: CodingSchemeProblem[],
+    afterProblems: CodingSchemeProblem[]
+  ): CodingSchemeProblem[] {
+    const beforeProblemKeys = new Set(beforeProblems.map(problem => (
+      VarCodingComponent.getCodingProblemKey(problem)
+    )));
+    return afterProblems.filter(problem => (
+      !beforeProblemKeys.has(VarCodingComponent.getCodingProblemKey(problem))
+    ));
+  }
+
+  private static getCodingProblemKey(problem: CodingSchemeProblem): string {
+    return [
+      problem.variableId,
+      problem.type,
+      problem.breaking ? 'breaking' : 'warning',
+      problem.code || ''
+    ].join('|');
+  }
+
+  private showPasteValidationWarning(problems: CodingSchemeProblem[]): void {
+    const problemDescriptions = Array.from(
+      new Set(problems.map(problem => this.translateService.instant(
+        `coding-problem.${problem.type}`
+      )))
+    );
+    this.messageDialog.open(MessageDialogComponent, {
+      width: '500px',
+      data: <MessageDialogData>{
+        title: this.translateService.instant('code.post-paste-validation.title'),
+        content: [
+          this.translateService.instant('code.post-paste-validation.content'),
+          ...problemDescriptions
+        ].join(' '),
+        type: problems.some(problem => problem.breaking) ?
+          MessageType.error :
+          MessageType.warning
+      }
+    });
   }
 
   editSourceParameters() {


### PR DESCRIPTION
## Summary
- Add a Schemer-internal single-code copy buffer that survives iframe/component recreation within a browser session.
- Warn before pasting when copied code references target-sensitive structures such as arrays, fragments, numeric rules, or boolean rules.
- Re-run scheme validation after paste and show newly introduced validation problems.
- Cover copy/paste behavior, persistence, warning flow, and post-paste validation with unit tests.

## Responses dependency
- This PR intentionally does not pin a concrete new @iqb/responses version yet.
- After the merged responses validation changes are published, update the dependency/lockfile in a follow-up commit or PR.

## Validation
- npm run test:cc -- --watch=false --browsers=ChromeHeadless
- npm run lint (passes with one pre-existing max-len warning in generate-coding-dialog.component.spec.ts)
- npm run build_cc