### PR TITLE
Fix variable export filename

### DIFF
--- a/projects/ngx-coding-components/src/lib/schemer/schemer.component.spec.ts
+++ b/projects/ngx-coding-components/src/lib/schemer/schemer.component.spec.ts
@@ -365,8 +365,20 @@ describe('SchemerComponent', () => {
     await component.exportVariable();
 
     expect(saveSpy).toHaveBeenCalled();
-    const args0 = saveSpy.calls.mostRecent().args[0] as string;
-    expect(args0).toContain('iqb-variable-export');
+    const [fileContent, filename] = saveSpy.calls.mostRecent().args;
+    const payload = JSON.parse(fileContent);
+    expect(payload).toEqual({
+      type: 'iqb-variable-export',
+      version: 1,
+      variableId: 'v1',
+      variableCoding: {
+        id: 'v1',
+        alias: 'A',
+        sourceType: 'BASE',
+        codes: []
+      }
+    });
+    expect(filename).toBe('v1.variable.json');
   });
 
   it('importVariable should return early for RO', async () => {

--- a/projects/ngx-coding-components/src/lib/services/file.service.spec.ts
+++ b/projects/ngx-coding-components/src/lib/services/file.service.spec.ts
@@ -29,7 +29,7 @@ describe('FileService', () => {
       href: string;
     };
 
-    expect(anchor.download).toBe('export.json');
+    expect(anchor.download).toBe('my.json');
     expect(anchor.href).toBe('blob:mock');
     expect(clickSpy).toHaveBeenCalled();
   });

--- a/projects/ngx-coding-components/src/lib/services/file.service.ts
+++ b/projects/ngx-coding-components/src/lib/services/file.service.ts
@@ -6,7 +6,7 @@ import { Injectable } from '@angular/core';
 export class FileService {
   static saveToFile(fileContent: string, filename: string): void {
     const anchor = document.createElement('a');
-    anchor.download = 'export.json';
+    anchor.download = filename;
     anchor.href = window.URL.createObjectURL(new File([fileContent], filename));
     anchor.click();
   }


### PR DESCRIPTION
## Summary

- Use the filename passed to `FileService.saveToFile()` as the browser download name.
- Strengthen the variable export specs to verify the full export payload and expected `.variable.json` filename.

## Context

Refs #64. The variable import/export feature already exists, but exported files were still suggested as `export.json` because the shared file service ignored its `filename` argument.

## Validation

- `npm run test:cc -- --include='projects/ngx-coding-components/src/lib/schemer/schemer.component.spec.ts' --include='projects/ngx-coding-components/src/lib/services/file.service.spec.ts'`
- `npm run build_cc`
- Browser download smoke test against the demo app: exporting `I01_HOTSPOT` suggested `I01_HOTSPOT.variable.json` and produced an `iqb-variable-export` payload.