### PR TITLE
Diagnose invalid variable lists in schemer

### DIFF
--- a/projects/ngx-coding-components/src/lib/dialogs/resolve-varlist-duplicates-dialog.component.spec.ts
+++ b/projects/ngx-coding-components/src/lib/dialogs/resolve-varlist-duplicates-dialog.component.spec.ts
@@ -1,6 +1,5 @@
 import { MatDialogRef } from '@angular/material/dialog';
 import { VariableInfo } from '@iqbspecs/variable-info/variable-info.interface';
-import { SchemerService } from '../services/schemer.service';
 import {
   ResolveVarListDuplicatesDialogComponent,
   ResolveVarListDuplicatesDialogData
@@ -11,21 +10,17 @@ describe('ResolveVarListDuplicatesDialogComponent', () => {
 
   const createComponent = (options: {
     varList: Partial<VarListEntry>[];
-    reservedIds?: string[];
   }) => {
     const dialogRef = {
       close: jasmine.createSpy('close')
     } as unknown as MatDialogRef<ResolveVarListDuplicatesDialogComponent>;
 
     const data: ResolveVarListDuplicatesDialogData = {
-      varList: options.varList as VariableInfo[],
-      reservedIds: options.reservedIds ?? []
+      varList: options.varList as VariableInfo[]
     };
 
-    const schemerService = jasmine.createSpyObj<SchemerService>('SchemerService', ['setVarList']);
-
     return {
-      component: new ResolveVarListDuplicatesDialogComponent(dialogRef, data, schemerService),
+      component: new ResolveVarListDuplicatesDialogComponent(dialogRef, data),
       dialogRef
     };
   };
@@ -55,45 +50,21 @@ describe('ResolveVarListDuplicatesDialogComponent', () => {
     expect(component.invalidAliasCount).toBeGreaterThan(0);
   });
 
-  it('autoFix should generate unique ids/aliases and respect reserved ids', () => {
+  it('should not mutate the input varList', () => {
+    const original = [
+      { id: 'AA', alias: 'AA' },
+      { id: 'AA', alias: 'BB' }
+    ];
     const { component } = createComponent({
-      varList: [
-        { id: 'A', alias: 'A' },
-        { id: 'A', alias: 'A' }
-      ],
-      reservedIds: ['VAR', 'A__']
+      varList: original
     });
 
-    component.autoFix();
+    component.varList[0].id = 'CHANGED';
 
-    expect(component.hasProblems).toBeFalse();
-
-    const ids = component.editedVarList.map(v => v.id);
-    const aliases = component.editedVarList.map(v => v.alias);
-
-    expect(new Set(ids).size).toBe(ids.length);
-    expect(new Set(aliases).size).toBe(aliases.length);
-
-    // none of the ids should collide with reserved set
-    expect(ids.map(v => v.toUpperCase())).not.toContain('VAR');
-    expect(ids.map(v => v.toUpperCase())).not.toContain('A__');
+    expect(original.map(v => v.id)).toEqual(['AA', 'AA']);
   });
 
-  it('reset should restore original varList', () => {
-    const { component } = createComponent({
-      varList: [
-        { id: 'AA', alias: 'AA' },
-        { id: 'BB', alias: 'BB' }
-      ]
-    });
-
-    component.editedVarList[0].id = 'CC';
-    component.reset();
-
-    expect(component.editedVarList.map(v => v.id)).toEqual(['AA', 'BB']);
-  });
-
-  it('apply should close dialog with a deep-copied varList and renameMap', () => {
+  it('close should close the dialog without a result payload', () => {
     const { component, dialogRef } = createComponent({
       varList: [
         { id: 'AA', alias: 'AA' },
@@ -101,29 +72,9 @@ describe('ResolveVarListDuplicatesDialogComponent', () => {
       ]
     });
 
-    component.editedVarList[0].id = 'AA_1';
-    component.apply();
+    component.close();
 
     expect(dialogRef.close).toHaveBeenCalled();
-    const payload = (dialogRef.close as jasmine.Spy).calls.mostRecent().args[0] as {
-      varList: VariableInfo[];
-      idRenameMap: Record<string, string>;
-    };
-
-    expect(payload.idRenameMap['AA']).toBe('AA_1');
-    expect(payload.varList.map(v => v.id)).toEqual(['AA_1', 'BB']);
-
-    // deep copy
-    expect(payload.varList[0]).not.toBe(component.editedVarList[0]);
-  });
-
-  it('sanitizeVarName should replace invalid chars and enforce min length', () => {
-    const sanitize = (ResolveVarListDuplicatesDialogComponent as unknown as
-      { sanitizeVarName: (raw: string) => string }).sanitizeVarName;
-
-    expect(sanitize('a')).toBe('a_');
-    expect(sanitize('')).toBe('VAR');
-    expect(sanitize('a b')).toBe('a_b');
-    expect(sanitize('ab')).toBe('ab');
+    expect((dialogRef.close as jasmine.Spy).calls.mostRecent().args.length).toBe(0);
   });
 });

--- a/projects/ngx-coding-components/src/lib/dialogs/resolve-varlist-duplicates-dialog.component.ts
+++ b/projects/ngx-coding-components/src/lib/dialogs/resolve-varlist-duplicates-dialog.component.ts
@@ -8,38 +8,23 @@ import {
 } from '@angular/material/dialog';
 import { VariableInfo } from '@iqbspecs/variable-info/variable-info.interface';
 import { MatButton } from '@angular/material/button';
-import { MatFormField } from '@angular/material/form-field';
-import { MatInput } from '@angular/material/input';
-import { FormsModule } from '@angular/forms';
 import {
-  SchemerService,
-  VARIABLE_NAME_CHECK_PATTERN
-} from '../services/schemer.service';
+  getVarListConflictAnalysis,
+  isInvalidVarListName
+} from '../services/schemer-varlist-validation';
 
 export interface ResolveVarListDuplicatesDialogData {
   varList: VariableInfo[];
-  reservedIds: string[];
-}
-
-export interface ResolveVarListDuplicatesDialogResult {
-  varList: VariableInfo[];
-  idRenameMap: Record<string, string>;
 }
 
 @Component({
   template: `
-    <h1 mat-dialog-title>Doppelte Variablen-IDs/Aliase auflösen</h1>
+    <h1 mat-dialog-title>Doppelte Variablen-IDs/Aliase</h1>
 
     <mat-dialog-content>
       <div style="margin-bottom: 10px;">
-        Bitte korrigiere doppelte IDs oder Aliase in der Variablenliste.
-      </div>
-
-      <div style="display:flex; gap:10px; margin-bottom: 12px;">
-        <button mat-raised-button color="primary" (click)="autoFix()">
-          Auto-Fix
-        </button>
-        <button mat-raised-button (click)="reset()">Zurücksetzen</button>
+        Die Variablenliste enthält doppelte oder ungültige IDs/Aliase.
+        Bitte korrigiere die Variablenliste und lade den Schemer neu.
       </div>
 
       <div
@@ -61,38 +46,24 @@ export interface ResolveVarListDuplicatesDialogResult {
         <div><b>Ungültige Aliase:</b> {{ invalidAliasCount }}</div>
         }
       </div>
-      } @for (v of editedVarList; track $index) {
+      } @for (v of varList; track $index) {
       <div
-        style="display:flex; gap:12px; align-items:flex-start; margin-bottom: 10px;"
+        style="display:flex; gap:12px; align-items:flex-start; margin-bottom: 8px;"
       >
-        <mat-form-field
+        <div
           style="flex: 1;"
           [class.duplicate-field]="isDuplicateId(v.id)"
           [class.invalid-field]="isInvalidId(v.id)"
         >
-          <input
-            matInput
-            placeholder="ID"
-            [(ngModel)]="v.id"
-            (input)="recompute()"
-            (ngModelChange)="recompute()"
-            (blur)="recompute()"
-          />
-        </mat-form-field>
-        <mat-form-field
+          <b>ID:</b> {{ v.id || '-' }}
+        </div>
+        <div
           style="flex: 1;"
           [class.duplicate-field]="isDuplicateAlias(v.alias || v.id)"
           [class.invalid-field]="isInvalidAlias(v.alias || v.id)"
         >
-          <input
-            matInput
-            placeholder="Alias"
-            [(ngModel)]="v.alias"
-            (input)="recompute()"
-            (ngModelChange)="recompute()"
-            (blur)="recompute()"
-          />
-        </mat-form-field>
+          <b>Alias:</b> {{ v.alias || v.id || '-' }}
+        </div>
       </div>
       }
     </mat-dialog-content>
@@ -101,31 +72,26 @@ export interface ResolveVarListDuplicatesDialogResult {
       <button
         mat-raised-button
         color="primary"
-        [disabled]="hasProblems"
-        (click)="apply()"
+        (click)="close()"
       >
-        Übernehmen
+        Schließen
       </button>
     </mat-dialog-actions>
   `,
   styles: [
-    '.duplicate-field { outline: 2px solid #b00020; outline-offset: 2px; border-radius: 3px; }',
-    '.invalid-field { outline: 2px solid #ff6f00; outline-offset: 2px; border-radius: 3px; }'
+    '.duplicate-field { outline: 2px solid #b00020; outline-offset: 2px; border-radius: 3px; padding: 4px; }',
+    '.invalid-field { outline: 2px solid #ff6f00; outline-offset: 2px; border-radius: 3px; padding: 4px; }'
   ],
   standalone: true,
   imports: [
     MatDialogTitle,
     MatDialogContent,
     MatDialogActions,
-    MatButton,
-    MatFormField,
-    MatInput,
-    FormsModule
+    MatButton
   ]
 })
 export class ResolveVarListDuplicatesDialogComponent {
-  private readonly originalVarList: VariableInfo[];
-  editedVarList: VariableInfo[];
+  varList: VariableInfo[];
 
   hasProblems = true;
   statusText = '';
@@ -140,124 +106,32 @@ export class ResolveVarListDuplicatesDialogComponent {
 
   constructor(
     private dialogRef: MatDialogRef<ResolveVarListDuplicatesDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: ResolveVarListDuplicatesDialogData,
-    // kept for future extensions (e.g. using shared helpers)
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    private _schemerService: SchemerService
+    @Inject(MAT_DIALOG_DATA) public data: ResolveVarListDuplicatesDialogData
   ) {
-    this.originalVarList = (data.varList || []).map(v => ({ ...v }));
-    this.editedVarList = (data.varList || []).map(v => ({ ...v }));
-    this.recompute();
-  }
-
-  reset(): void {
-    this.editedVarList = this.originalVarList.map(v => ({ ...v }));
-    this.recompute();
-  }
-
-  autoFix(): void {
-    const reserved = new Set(
-      (this.data.reservedIds || []).map(v => v.toUpperCase())
-    );
-
-    const makeUnique = (
-      base: string,
-      used: Set<string>,
-      reservedSet: Set<string>
-    ): string => {
-      const trimmed = (base || '').trim();
-      const start = ResolveVarListDuplicatesDialogComponent.sanitizeVarName(
-        trimmed || 'VAR'
-      );
-      let candidate = start;
-      let i = 1;
-      const isBlocked = (val: string) => used.has(val.toUpperCase()) || reservedSet.has(val.toUpperCase());
-      while (isBlocked(candidate)) {
-        candidate = `${start}_${i}`;
-        i += 1;
-      }
-      used.add(candidate.toUpperCase());
-      return candidate;
-    };
-
-    const usedIds = new Set<string>();
-    const usedAliases = new Set<string>();
-
-    this.editedVarList = this.editedVarList.map(v => {
-      const proposedId = (v.id || '').trim();
-      const newId = makeUnique(proposedId || 'VAR', usedIds, reserved);
-
-      const proposedAlias = (v.alias || '').trim();
-      const aliasBase = proposedAlias || newId;
-      const newAliasOrId = makeUnique(aliasBase, usedAliases, new Set());
-
-      return {
-        ...v,
-        id: newId,
-        alias: newAliasOrId
-      };
-    });
-
+    this.varList = (data.varList || []).map(v => ({ ...v }));
     this.recompute();
   }
 
   recompute(): void {
-    const idCounts = this.getCounts(
-      this.editedVarList.map(v => (v.id || '').trim())
-    );
-    const aliasCounts = this.getCounts(
-      this.editedVarList.map(v => (v.alias || v.id || '').trim())
-    );
+    const analysis = getVarListConflictAnalysis(this.varList);
 
-    this.duplicateIds = new Set(
-      Array.from(idCounts.entries())
-        .filter(([, c]) => c > 1)
-        .map(([k]) => k)
-    );
-    this.duplicateAliases = new Set(
-      Array.from(aliasCounts.entries())
-        .filter(([, c]) => c > 1)
-        .map(([k]) => k)
-    );
-
-    this.duplicateIdValues = Array.from(this.duplicateIds.values()).sort();
-    this.duplicateAliasValues = Array.from(
-      this.duplicateAliases.values()
-    ).sort();
-
-    this.invalidIdCount = this.editedVarList.filter(v => {
-      const id = (v.id || '').trim();
-      return !id || !VARIABLE_NAME_CHECK_PATTERN.test(id);
-    }).length;
-
-    this.invalidAliasCount = this.editedVarList.filter(v => {
-      const aliasOrId = (v.alias || v.id || '').trim();
-      return !aliasOrId || !VARIABLE_NAME_CHECK_PATTERN.test(aliasOrId);
-    }).length;
-
-    const hasInvalid = this.editedVarList.some(v => {
-      const id = (v.id || '').trim();
-      const aliasOrId = (v.alias || v.id || '').trim();
-      if (!id || !VARIABLE_NAME_CHECK_PATTERN.test(id)) {
-        return true;
-      }
-      return !aliasOrId || !VARIABLE_NAME_CHECK_PATTERN.test(aliasOrId);
-    });
-
-    const hasDupId = Array.from(idCounts.values()).some(c => c > 1);
-    const hasDupAlias = Array.from(aliasCounts.values()).some(c => c > 1);
-
-    this.hasProblems = hasInvalid || hasDupId || hasDupAlias;
+    this.duplicateIds = analysis.duplicateIds;
+    this.duplicateAliases = analysis.duplicateAliases;
+    this.duplicateIdValues = analysis.duplicateIdValues;
+    this.duplicateAliasValues = analysis.duplicateAliasValues;
+    this.invalidIdCount = analysis.invalidIdCount;
+    this.invalidAliasCount = analysis.invalidAliasCount;
+    this.hasProblems = analysis.hasProblems;
 
     if (this.hasProblems) {
       const problems: string[] = [];
-      if (hasInvalid) {
+      if (analysis.hasInvalid) {
         problems.push('Ungültige ID/Alias (nur [a-zA-Z0-9_], min. 2 Zeichen)');
       }
-      if (hasDupId) {
+      if (analysis.hasDuplicateId) {
         problems.push('Doppelte IDs');
       }
-      if (hasDupAlias) {
+      if (analysis.hasDuplicateAlias) {
         problems.push('Doppelte Aliase');
       }
       this.statusText = problems.join(' | ');
@@ -276,56 +150,13 @@ export class ResolveVarListDuplicatesDialogComponent {
     return !!key && this.duplicateAliases.has(key);
   }
 
-  private readonly variableNameCheckPattern = VARIABLE_NAME_CHECK_PATTERN;
-
-  isInvalidId = (value: string | null | undefined): boolean => {
-    const v = (value || '').trim();
-    return !v || !this.variableNameCheckPattern.test(v);
-  };
+  isInvalidId = isInvalidVarListName;
 
   isInvalidAlias(value: string | null | undefined): boolean {
     return this.isInvalidId(value);
   }
 
-  apply(): void {
-    const renameMap: Record<string, string> = {};
-    this.originalVarList.forEach((orig, idx) => {
-      const edited = this.editedVarList[idx];
-      if (edited && orig.id !== edited.id) {
-        renameMap[orig.id] = edited.id;
-      }
-    });
-
-    this.dialogRef.close({
-      varList: this.editedVarList.map(v => ({ ...v })),
-      idRenameMap: renameMap
-    });
-  }
-
-  // eslint-disable-next-line class-methods-use-this
-  private getCounts(values: string[]): Map<string, number> {
-    const m = new Map<string, number>();
-    values
-      .map(v => (v || '').trim())
-      .filter(v => !!v)
-      .forEach(v => {
-        const key = v.toUpperCase();
-        m.set(key, (m.get(key) || 0) + 1);
-      });
-    return m;
-  }
-
-  private static sanitizeVarName(raw: string): string {
-    const cleaned = (raw || '').trim().replace(/[^a-zA-Z0-9_]/g, '_');
-
-    if (cleaned.length >= 2) {
-      return cleaned;
-    }
-
-    if (cleaned.length === 1) {
-      return `${cleaned}_`;
-    }
-
-    return 'VAR';
+  close(): void {
+    this.dialogRef.close();
   }
 }

--- a/projects/ngx-coding-components/src/lib/schemer/schemer.component.html
+++ b/projects/ngx-coding-components/src/lib/schemer/schemer.component.html
@@ -1,4 +1,21 @@
 <div class="scheme-body fx-row-space-between-stretch">
+  @if (hasVarListDuplicateConflict) {
+  <div style="margin: 20px">
+    <div style="margin-bottom: 12px;">
+      Bitte korrigiere die Variablenliste und lade den Schemer neu.
+    </div>
+    <div class="fx-row-start-center fx-gap-10">
+      <button mat-button (click)="showSchemerInfo()">
+        <mat-icon>info</mat-icon>
+        {{ "varList.info" | translate }}
+      </button>
+      <button mat-button (click)="showCodingScheme()">
+        <mat-icon>reorder</mat-icon>
+        {{ "varList.show" | translate }}
+      </button>
+    </div>
+  </div>
+  } @else {
   @if (basicVariables && basicVariables.length !== 0) {
   <div class="navi-bar fx-column-space-between-stretch">
     <div class="var-scheme-list fx-flex">
@@ -160,4 +177,5 @@
     [varCoding]="selectedCoding$ | async"
     class="var-coding-container fx-flex-row-100"
   ></var-coding>
+  }
 </div>

--- a/projects/ngx-coding-components/src/lib/schemer/schemer.component.spec.ts
+++ b/projects/ngx-coding-components/src/lib/schemer/schemer.component.spec.ts
@@ -1,11 +1,13 @@
 /* eslint-disable max-classes-per-file */
+import { fakeAsync, tick } from '@angular/core/testing';
 import { CodingSchemeFactory, CodingSchemeProblem } from '@iqb/responses';
 import { CodingFactory } from '@iqb/responses/coding-factory';
 import { VariableCodingData } from '@iqbspecs/coding-scheme/coding-scheme.interface';
 import { VariableInfo } from '@iqbspecs/variable-info/variable-info.interface';
-import { of } from 'rxjs';
+import { of, Subject } from 'rxjs';
 import { MessageDialogComponent } from '../dialogs/message-dialog.component';
 import { FileService } from '../services/file.service';
+import { VarCodingComponent } from '../var-coding/var-coding.component';
 import { SchemerComponent } from './schemer.component';
 
 class FakeTranslateService {
@@ -40,7 +42,6 @@ describe('SchemerComponent', () => {
 
   let schemerFacade: {
     tryResolveVarListDuplicates: jasmine.Spy;
-    varListDuplicatesResolved$: { subscribe: () => { unsubscribe: () => void } };
   };
 
   let dialog: FakeMatDialog;
@@ -75,8 +76,7 @@ describe('SchemerComponent', () => {
     };
 
     schemerFacade = {
-      tryResolveVarListDuplicates: jasmine.createSpy('tryResolveVarListDuplicates').and.returnValue(false),
-      varListDuplicatesResolved$: { subscribe: () => ({ unsubscribe: () => undefined }) }
+      tryResolveVarListDuplicates: jasmine.createSpy('tryResolveVarListDuplicates').and.returnValue(false)
     };
 
     component = new SchemerComponent(
@@ -107,7 +107,84 @@ describe('SchemerComponent', () => {
     component.updateVariableLists();
 
     expect(validateSpy).not.toHaveBeenCalled();
+    expect(component.hasVarListDuplicateConflict).toBeTrue();
+    expect(component.basicVariables).toEqual([]);
+    expect(component.selectedCoding$.getValue()).toBeNull();
   });
+
+  it('updateVariableLists should not mutate codingScheme while varList duplicate conflict is active', () => {
+    schemerFacade.tryResolveVarListDuplicates.and.returnValue(true);
+
+    const orphanEmptyBase: VariableCodingData = {
+      id: 'orphan',
+      alias: 'orphan',
+      sourceType: 'BASE',
+      label: 'orphan',
+      codeModel: 'MANUAL_AND_RULES',
+      manualInstruction: '',
+      codes: [],
+      processing: []
+    } as unknown as VariableCodingData;
+    const existingBase: VariableCodingData = {
+      id: 'existing',
+      alias: 'existing',
+      sourceType: 'BASE',
+      codes: []
+    } as unknown as VariableCodingData;
+
+    schemerService.setVarList([
+      {
+        id: 'existing',
+        alias: 'existing',
+        type: 'string',
+        format: '',
+        multiple: false,
+        nullable: false,
+        values: [],
+        valuePositionLabels: []
+      } as unknown as VariableInfo,
+      {
+        id: 'missing',
+        alias: 'missing',
+        type: 'string',
+        format: '',
+        multiple: false,
+        nullable: false,
+        values: [],
+        valuePositionLabels: []
+      } as unknown as VariableInfo
+    ]);
+    schemerService.setCodingScheme({
+      variableCodings: [orphanEmptyBase, existingBase]
+    } as unknown as never);
+
+    const createSpy = spyOn(CodingFactory, 'createCodingVariable');
+
+    component.updateVariableLists();
+
+    const ids = (schemerService.codingScheme?.variableCodings || []).map(v => v.id);
+    expect(ids).toEqual(['orphan', 'existing']);
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it('varCodingElement setter should subscribe when var-coding appears after conflict recovery', fakeAsync(() => {
+    const emitSpy = spyOn(component.codingSchemeChanged, 'emit');
+    const changes$ = new Subject<VariableCodingData | null>();
+
+    schemerService.setCodingScheme({ variableCodings: [] } as unknown as never);
+    schemerFacade.tryResolveVarListDuplicates.and.returnValue(false);
+
+    component.varCodingElement = {
+      varCodingChanged: changes$.asObservable()
+    } as unknown as VarCodingComponent;
+
+    changes$.next(null);
+    tick(300);
+
+    expect(schemerFacade.tryResolveVarListDuplicates).toHaveBeenCalled();
+    expect(emitSpy).toHaveBeenCalledWith(schemerService.codingScheme);
+    changes$.complete();
+  }));
 
   it('updateVariableLists should remove orphan empty BASE variables not in varList', () => {
     const orphanEmptyBase: VariableCodingData = {

--- a/projects/ngx-coding-components/src/lib/schemer/schemer.component.ts
+++ b/projects/ngx-coding-components/src/lib/schemer/schemer.component.ts
@@ -1,5 +1,4 @@
 import {
-  AfterViewInit,
   Component,
   EventEmitter,
   Input,
@@ -82,10 +81,23 @@ import { SchemerInfoDialogComponent } from '../dialogs/schemer-info-dialog.compo
     MatDivider
   ]
 })
-export class SchemerComponent implements OnDestroy, AfterViewInit {
-  @ViewChild(VarCodingComponent) varCodingElement:
-  | VarCodingComponent
-  | undefined;
+export class SchemerComponent implements OnDestroy {
+  @ViewChild(VarCodingComponent)
+  set varCodingElement(value: VarCodingComponent | undefined) {
+    this.varCodingChangedSubscription?.unsubscribe();
+    this.varCodingChangedSubscription = null;
+
+    if (!value) return;
+
+    this.varCodingChangedSubscription = value.varCodingChanged
+      .pipe(debounceTime(300))
+      .subscribe(() => {
+        this.updateVariableLists();
+        if (!this.hasVarListDuplicateConflict) {
+          this.codingSchemeChanged.emit(this.schemerService.codingScheme);
+        }
+      });
+  }
 
   @Output() codingSchemeChanged = new EventEmitter<CodingScheme | null>();
 
@@ -125,8 +137,8 @@ export class SchemerComponent implements OnDestroy, AfterViewInit {
   codingStatus: { [id: string]: string } = {};
   selectedCoding$ = new BehaviorSubject<VariableCodingData | null>(null);
   problems: CodingSchemeProblem[] = [];
+  hasVarListDuplicateConflict = false;
   varCodingChangedSubscription: Subscription | null = null;
-  varListDuplicatesResolvedSubscription: Subscription | null = null;
 
   constructor(
     private translateService: TranslateService,
@@ -153,32 +165,17 @@ export class SchemerComponent implements OnDestroy, AfterViewInit {
     });
   }
 
-  ngAfterViewInit() {
-    if (this.varCodingElement) {
-      this.varCodingChangedSubscription = this.varCodingElement.varCodingChanged
-        .pipe(debounceTime(300))
-        .subscribe(() => {
-          this.updateVariableLists();
-          this.codingSchemeChanged.emit(this.schemerService.codingScheme);
-        });
-    }
-
-    this.varListDuplicatesResolvedSubscription =
-      this.schemerFacade.varListDuplicatesResolved$.subscribe(result => {
-        const renameMap = result.idRenameMap || {};
-        const selected = this.selectedCoding$.getValue();
-        if (selected && renameMap[selected.id]) {
-          selected.id = renameMap[selected.id];
-        }
-        this.codingSchemeChanged.emit(this.schemerService.codingScheme);
-        this.updateVariableLists();
-      });
-  }
-
   updateVariableLists() {
     if (this.schemerFacade.tryResolveVarListDuplicates()) {
+      this.hasVarListDuplicateConflict = true;
+      this.selectVarScheme();
+      this.basicVariables = [];
+      this.derivedVariables = [];
+      this.codingStatus = {};
+      this.problems = [];
       return;
     }
+    this.hasVarListDuplicateConflict = false;
 
     if (
       this.schemerService.varList &&
@@ -789,6 +786,5 @@ export class SchemerComponent implements OnDestroy, AfterViewInit {
 
   ngOnDestroy(): void {
     if (this.varCodingChangedSubscription !== null) this.varCodingChangedSubscription.unsubscribe();
-    if (this.varListDuplicatesResolvedSubscription !== null) this.varListDuplicatesResolvedSubscription.unsubscribe();
   }
 }

--- a/projects/ngx-coding-components/src/lib/services/schemer-facade.service.spec.ts
+++ b/projects/ngx-coding-components/src/lib/services/schemer-facade.service.spec.ts
@@ -36,6 +36,40 @@ describe('SchemerFacadeService', () => {
     afterClosed$.complete();
   });
 
+  it('tryResolveVarListDuplicates should stop blocking while resolving if the current varList becomes valid', () => {
+    const service = createService();
+
+    schemerService.setVarList([
+      { id: 'A', alias: 'A' } as never,
+      { id: 'A', alias: 'B' } as never
+    ]);
+
+    const afterClosed$ = new Subject<unknown>();
+    (dialog.open as jasmine.Spy).and.returnValue({
+      afterClosed: () => afterClosed$.asObservable()
+    });
+
+    expect(service.tryResolveVarListDuplicates()).toBeTrue();
+
+    schemerService.setVarList([
+      { id: 'AA', alias: 'AA' } as never,
+      { id: 'BB', alias: 'BB' } as never
+    ]);
+
+    expect(service.tryResolveVarListDuplicates()).toBeFalse();
+
+    afterClosed$.next(null);
+    afterClosed$.complete();
+
+    schemerService.setVarList([
+      { id: 'A', alias: 'A' } as never,
+      { id: 'A', alias: 'B' } as never
+    ]);
+
+    expect(service.tryResolveVarListDuplicates()).toBeTrue();
+    expect(dialog.open).toHaveBeenCalledTimes(2);
+  });
+
   it('tryResolveVarListDuplicates should return false for an empty varList', () => {
     const service = createService();
 

--- a/projects/ngx-coding-components/src/lib/services/schemer-facade.service.spec.ts
+++ b/projects/ngx-coding-components/src/lib/services/schemer-facade.service.spec.ts
@@ -1,6 +1,5 @@
 import { MatDialog } from '@angular/material/dialog';
-import { firstValueFrom, Subject } from 'rxjs';
-import { take } from 'rxjs/operators';
+import { Subject } from 'rxjs';
 import { ResolveVarListDuplicatesDialogComponent } from '../dialogs/resolve-varlist-duplicates-dialog.component';
 import { SchemerFacadeService } from './schemer-facade.service';
 import { SchemerService } from './schemer.service';
@@ -18,7 +17,7 @@ describe('SchemerFacadeService', () => {
 
   const createService = () => new SchemerFacadeService(schemerService, dialog);
 
-  it('tryResolveVarListDuplicates should return false if already resolving', () => {
+  it('tryResolveVarListDuplicates should keep blocking while already resolving', () => {
     const service = createService();
 
     schemerService.setVarList([
@@ -32,7 +31,7 @@ describe('SchemerFacadeService', () => {
     });
 
     expect(service.tryResolveVarListDuplicates()).toBeTrue();
-    expect(service.tryResolveVarListDuplicates()).toBeFalse();
+    expect(service.tryResolveVarListDuplicates()).toBeTrue();
 
     afterClosed$.complete();
   });
@@ -49,12 +48,31 @@ describe('SchemerFacadeService', () => {
     const service = createService();
 
     schemerService.setVarList([
-      { id: 'A', alias: 'A' } as never,
-      { id: 'B', alias: 'B' } as never
+      { id: 'AA', alias: 'AA' } as never,
+      { id: 'BB', alias: 'BB' } as never
     ]);
 
     expect(service.tryResolveVarListDuplicates()).toBeFalse();
     expect(dialog.open).not.toHaveBeenCalled();
+  });
+
+  it('tryResolveVarListDuplicates should open dialog when invalid ids or aliases exist', () => {
+    const service = createService();
+
+    schemerService.setVarList([
+      { id: 'A', alias: 'AA' } as never,
+      { id: 'BB', alias: 'x' } as never
+    ]);
+
+    (dialog.open as jasmine.Spy).and.returnValue({
+      afterClosed: () => new Subject<unknown>().asObservable()
+    });
+
+    expect(service.tryResolveVarListDuplicates()).toBeTrue();
+    expect(dialog.open).toHaveBeenCalled();
+    expect((dialog.open as jasmine.Spy).calls.mostRecent().args[0]).toBe(
+      ResolveVarListDuplicatesDialogComponent
+    );
   });
 
   it('tryResolveVarListDuplicates should open dialog when duplicates exist', () => {
@@ -76,7 +94,7 @@ describe('SchemerFacadeService', () => {
     );
   });
 
-  it('tryResolveVarListDuplicates should remember dismissed signature and not reopen dialog for same list', () => {
+  it('tryResolveVarListDuplicates should keep blocking a dismissed duplicate signature', () => {
     const service = createService();
 
     schemerService.setVarList([
@@ -93,11 +111,11 @@ describe('SchemerFacadeService', () => {
     afterClosed$.next(null);
     afterClosed$.complete();
 
-    expect(service.tryResolveVarListDuplicates()).toBeFalse();
+    expect(service.tryResolveVarListDuplicates()).toBeTrue();
     expect(dialog.open).toHaveBeenCalledTimes(1);
   });
 
-  it('tryResolveVarListDuplicates should apply rename map to codingScheme and emit result', async () => {
+  it('tryResolveVarListDuplicates should not mutate varList or codingScheme when dialog closes', () => {
     const service = createService();
 
     schemerService.setVarList([
@@ -114,8 +132,6 @@ describe('SchemerFacadeService', () => {
       ]
     } as never);
 
-    const emitted = firstValueFrom(service.varListDuplicatesResolved$.pipe(take(1)));
-
     const afterClosed$ = new Subject<unknown>();
     (dialog.open as jasmine.Spy).and.returnValue({
       afterClosed: () => afterClosed$.asObservable()
@@ -123,28 +139,15 @@ describe('SchemerFacadeService', () => {
 
     expect(service.tryResolveVarListDuplicates()).toBeTrue();
 
-    const dialogResult = {
-      varList: [
-        { id: 'A_1', alias: 'A_1' },
-        { id: 'A_2', alias: 'B' }
-      ],
-      idRenameMap: {
-        A: 'A_1'
-      }
-    };
-
-    afterClosed$.next(dialogResult);
+    afterClosed$.next(null);
     afterClosed$.complete();
 
-    const resolved = await emitted;
-    expect(resolved.idRenameMap['A']).toBe('A_1');
-
-    expect(schemerService.varList.map(v => v.id)).toEqual(['A_1', 'A_2']);
+    expect(schemerService.varList.map(v => v.id)).toEqual(['A', 'A']);
 
     const vcIds = (schemerService.codingScheme?.variableCodings || []).map(v => v.id);
-    expect(vcIds).toEqual(['A_1', 'X']);
+    expect(vcIds).toEqual(['A', 'X']);
 
     const derivedSources = (schemerService.codingScheme?.variableCodings || [])[1].deriveSources;
-    expect(derivedSources).toEqual(['A_1']);
+    expect(derivedSources).toEqual(['A']);
   });
 });

--- a/projects/ngx-coding-components/src/lib/services/schemer-facade.service.ts
+++ b/projects/ngx-coding-components/src/lib/services/schemer-facade.service.ts
@@ -22,12 +22,9 @@ export class SchemerFacadeService {
   }
 
   tryResolveVarListDuplicates(): boolean {
-    if (this.resolvingVarListDuplicates) {
-      return true;
-    }
-
     const varList = this.schemerService.varList || [];
     if (varList.length === 0) {
+      this.dismissedVarListDuplicateSignature = null;
       return false;
     }
 
@@ -36,6 +33,10 @@ export class SchemerFacadeService {
     if (!analysis.hasProblems) {
       this.dismissedVarListDuplicateSignature = null;
       return false;
+    }
+
+    if (this.resolvingVarListDuplicates) {
+      return true;
     }
 
     if (this.dismissedVarListDuplicateSignature === analysis.signature) {
@@ -57,7 +58,14 @@ export class SchemerFacadeService {
 
     dialogRef.afterClosed().subscribe(() => {
       this.resolvingVarListDuplicates = false;
-      this.dismissedVarListDuplicateSignature = analysis.signature;
+      const currentAnalysis = getVarListConflictAnalysis(
+        this.schemerService.varList || []
+      );
+      this.dismissedVarListDuplicateSignature =
+        currentAnalysis.hasProblems &&
+        currentAnalysis.signature === analysis.signature ?
+          analysis.signature :
+          null;
     });
 
     return true;

--- a/projects/ngx-coding-components/src/lib/services/schemer-facade.service.ts
+++ b/projects/ngx-coding-components/src/lib/services/schemer-facade.service.ts
@@ -1,12 +1,9 @@
 import { Injectable } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { VariableInfo } from '@iqbspecs/variable-info/variable-info.interface';
-import { Observable, Subject } from 'rxjs';
 import { SchemerService } from './schemer.service';
-import {
-  ResolveVarListDuplicatesDialogComponent,
-  ResolveVarListDuplicatesDialogResult
-} from '../dialogs/resolve-varlist-duplicates-dialog.component';
+import { ResolveVarListDuplicatesDialogComponent } from '../dialogs/resolve-varlist-duplicates-dialog.component';
+import { getVarListConflictAnalysis } from './schemer-varlist-validation';
 
 @Injectable({
   providedIn: 'root'
@@ -14,13 +11,6 @@ import {
 export class SchemerFacadeService {
   private resolvingVarListDuplicates = false;
   private dismissedVarListDuplicateSignature: string | null = null;
-
-  private readonly _varListDuplicatesResolved =
-    new Subject<ResolveVarListDuplicatesDialogResult>();
-
-  get varListDuplicatesResolved$(): Observable<ResolveVarListDuplicatesDialogResult> {
-    return this._varListDuplicatesResolved.asObservable();
-  }
 
   constructor(
     private schemerService: SchemerService,
@@ -33,7 +23,7 @@ export class SchemerFacadeService {
 
   tryResolveVarListDuplicates(): boolean {
     if (this.resolvingVarListDuplicates) {
-      return false;
+      return true;
     }
 
     const varList = this.schemerService.varList || [];
@@ -41,47 +31,18 @@ export class SchemerFacadeService {
       return false;
     }
 
-    const signature = varList
-      .map(
-        v => `${(v.id || '').trim().toUpperCase()}|${(v.alias || v.id || '')
-          .trim()
-          .toUpperCase()}`
-      )
-      .join(';;');
+    const analysis = getVarListConflictAnalysis(varList);
 
-    if (this.dismissedVarListDuplicateSignature === signature) {
+    if (!analysis.hasProblems) {
+      this.dismissedVarListDuplicateSignature = null;
       return false;
     }
 
-    const idCounts = new Map<string, number>();
-    const aliasCounts = new Map<string, number>();
-
-    varList.forEach(v => {
-      const id = (v.id || '').trim();
-      const aliasOrId = (v.alias || v.id || '').trim();
-
-      if (id) {
-        const key = id.toUpperCase();
-        idCounts.set(key, (idCounts.get(key) || 0) + 1);
-      }
-      if (aliasOrId) {
-        const key = aliasOrId.toUpperCase();
-        aliasCounts.set(key, (aliasCounts.get(key) || 0) + 1);
-      }
-    });
-
-    const hasDuplicateId = Array.from(idCounts.values()).some(c => c > 1);
-    const hasDuplicateAlias = Array.from(aliasCounts.values()).some(c => c > 1);
-
-    if (!hasDuplicateId && !hasDuplicateAlias) {
-      return false;
+    if (this.dismissedVarListDuplicateSignature === analysis.signature) {
+      return true;
     }
 
     this.resolvingVarListDuplicates = true;
-
-    const reservedIds = this.schemerService.codingScheme?.variableCodings ?
-      this.schemerService.codingScheme.variableCodings.map(c => c.id) :
-      [];
 
     const dialogRef = this.dialog.open(
       ResolveVarListDuplicatesDialogComponent,
@@ -89,42 +50,14 @@ export class SchemerFacadeService {
         width: '850px',
         disableClose: true,
         data: {
-          varList: this.schemerService.varList,
-          reservedIds
+          varList: this.schemerService.varList
         }
       }
     );
 
-    dialogRef.afterClosed().subscribe(dialogResult => {
+    dialogRef.afterClosed().subscribe(() => {
       this.resolvingVarListDuplicates = false;
-
-      if (!dialogResult) {
-        this.dismissedVarListDuplicateSignature = signature;
-        return;
-      }
-
-      const result = dialogResult as ResolveVarListDuplicatesDialogResult;
-      this.dismissedVarListDuplicateSignature = null;
-
-      this.schemerService.setVarList((result.varList || []).map(v => ({
-        ...v
-      })));
-
-      if (this.schemerService.codingScheme?.variableCodings) {
-        const renameMap = result.idRenameMap || {};
-
-        this.schemerService.codingScheme.variableCodings.forEach(vc => {
-          const newId = renameMap[vc.id];
-          if (newId) {
-            vc.id = newId;
-          }
-          if (vc.deriveSources && vc.deriveSources.length > 0) {
-            vc.deriveSources = vc.deriveSources.map(ds => renameMap[ds] || ds);
-          }
-        });
-      }
-
-      this._varListDuplicatesResolved.next(result);
+      this.dismissedVarListDuplicateSignature = analysis.signature;
     });
 
     return true;

--- a/projects/ngx-coding-components/src/lib/services/schemer-varlist-validation.spec.ts
+++ b/projects/ngx-coding-components/src/lib/services/schemer-varlist-validation.spec.ts
@@ -1,0 +1,58 @@
+import { VariableInfo } from '@iqbspecs/variable-info/variable-info.interface';
+import {
+  getVarListConflictAnalysis,
+  isInvalidVarListName
+} from './schemer-varlist-validation';
+
+describe('schemer-varlist-validation', () => {
+  it('isInvalidVarListName should require at least two valid characters', () => {
+    expect(isInvalidVarListName('AA')).toBeFalse();
+    expect(isInvalidVarListName('A')).toBeTrue();
+    expect(isInvalidVarListName('A B')).toBeTrue();
+    expect(isInvalidVarListName('')).toBeTrue();
+  });
+
+  it('getVarListConflictAnalysis should detect duplicate ids and aliases', () => {
+    const analysis = getVarListConflictAnalysis([
+      { id: 'AA', alias: 'Alias' },
+      { id: 'aa', alias: 'alias' },
+      { id: 'BB', alias: 'Other' }
+    ] as VariableInfo[]);
+
+    expect(analysis.hasProblems).toBeTrue();
+    expect(analysis.hasDuplicateId).toBeTrue();
+    expect(analysis.hasDuplicateAlias).toBeTrue();
+    expect(analysis.duplicateIdValues).toEqual(['AA']);
+    expect(analysis.duplicateAliasValues).toEqual(['ALIAS']);
+  });
+
+  it('getVarListConflictAnalysis should detect invalid ids and aliases', () => {
+    const analysis = getVarListConflictAnalysis([
+      { id: 'A', alias: 'AA' },
+      { id: 'BB', alias: 'x' }
+    ] as VariableInfo[]);
+
+    expect(analysis.hasProblems).toBeTrue();
+    expect(analysis.hasInvalid).toBeTrue();
+    expect(analysis.invalidIdCount).toBe(1);
+    expect(analysis.invalidAliasCount).toBe(1);
+  });
+
+  it('getVarListConflictAnalysis should provide a stable normalized signature', () => {
+    const analysis = getVarListConflictAnalysis([
+      { id: ' aa ', alias: ' Alias ' },
+      { id: 'BB' }
+    ] as VariableInfo[]);
+
+    expect(analysis.signature).toBe('AA|ALIAS;;BB|BB');
+  });
+
+  it('getVarListConflictAnalysis should report no problems for valid unique variables', () => {
+    const analysis = getVarListConflictAnalysis([
+      { id: 'AA', alias: 'AliasAA' },
+      { id: 'BB', alias: 'AliasBB' }
+    ] as VariableInfo[]);
+
+    expect(analysis.hasProblems).toBeFalse();
+  });
+});

--- a/projects/ngx-coding-components/src/lib/services/schemer-varlist-validation.ts
+++ b/projects/ngx-coding-components/src/lib/services/schemer-varlist-validation.ts
@@ -1,0 +1,87 @@
+import { VariableInfo } from '@iqbspecs/variable-info/variable-info.interface';
+import { VARIABLE_NAME_CHECK_PATTERN } from './schemer.service';
+
+export type VarListConflictAnalysis = {
+  signature: string;
+  duplicateIds: Set<string>;
+  duplicateAliases: Set<string>;
+  duplicateIdValues: string[];
+  duplicateAliasValues: string[];
+  invalidIdCount: number;
+  invalidAliasCount: number;
+  hasDuplicateId: boolean;
+  hasDuplicateAlias: boolean;
+  hasInvalid: boolean;
+  hasProblems: boolean;
+};
+
+const normaliseName = (value: string | null | undefined): string => (value || '').trim();
+
+const normaliseKey = (value: string | null | undefined): string => normaliseName(value).toUpperCase();
+
+const getCounts = (values: string[]): Map<string, number> => {
+  const counts = new Map<string, number>();
+  values
+    .map(normaliseName)
+    .filter(v => !!v)
+    .forEach(v => {
+      const key = v.toUpperCase();
+      counts.set(key, (counts.get(key) || 0) + 1);
+    });
+  return counts;
+};
+
+export const isInvalidVarListName = (
+  value: string | null | undefined
+): boolean => {
+  const name = normaliseName(value);
+  return !name || !VARIABLE_NAME_CHECK_PATTERN.test(name);
+};
+
+export const getVarListConflictAnalysis = (
+  varList: VariableInfo[] = []
+): VarListConflictAnalysis => {
+  const signature = varList
+    .map(v => `${normaliseKey(v.id)}|${normaliseKey(v.alias || v.id)}`)
+    .join(';;');
+
+  const idCounts = getCounts(varList.map(v => normaliseName(v.id)));
+  const aliasCounts = getCounts(
+    varList.map(v => normaliseName(v.alias || v.id))
+  );
+
+  const duplicateIds = new Set(
+    Array.from(idCounts.entries())
+      .filter(([, c]) => c > 1)
+      .map(([k]) => k)
+  );
+  const duplicateAliases = new Set(
+    Array.from(aliasCounts.entries())
+      .filter(([, c]) => c > 1)
+      .map(([k]) => k)
+  );
+
+  const invalidIdCount = varList.filter(v => isInvalidVarListName(v.id))
+    .length;
+  const invalidAliasCount = varList.filter(v => (
+    isInvalidVarListName(v.alias || v.id)
+  )).length;
+
+  const hasDuplicateId = duplicateIds.size > 0;
+  const hasDuplicateAlias = duplicateAliases.size > 0;
+  const hasInvalid = invalidIdCount > 0 || invalidAliasCount > 0;
+
+  return {
+    signature,
+    duplicateIds,
+    duplicateAliases,
+    duplicateIdValues: Array.from(duplicateIds.values()).sort(),
+    duplicateAliasValues: Array.from(duplicateAliases.values()).sort(),
+    invalidIdCount,
+    invalidAliasCount,
+    hasDuplicateId,
+    hasDuplicateAlias,
+    hasInvalid,
+    hasProblems: hasDuplicateId || hasDuplicateAlias || hasInvalid
+  };
+};


### PR DESCRIPTION
## Summary

- remove automatic variable-list fixing from the Schemer duplicate/invalid variable dialog
- make the dialog diagnostic-only and block the coding tab while conflicts are present
- centralize variable-list conflict detection in a shared helper used by both Facade and dialog
- add coverage for conflict detection, blocked synchronization, and dynamic var-coding subscription recovery

Closes #138

## Validation

- `git diff --check`
- targeted specs: `16 SUCCESS`
- `npm run test:cc`: `267 SUCCESS`
- `npm run lint`: no errors; one pre-existing `max-len` warning in `generate-coding-dialog.component.spec.ts:381`