### PR TITLE
Fix duplicate guard lifecycle

### DIFF
--- a/projects/ngx-coding-components/src/lib/schemer/schemer.component.spec.ts
+++ b/projects/ngx-coding-components/src/lib/schemer/schemer.component.spec.ts
@@ -42,6 +42,7 @@ describe('SchemerComponent', () => {
 
   let schemerFacade: {
     tryResolveVarListDuplicates: jasmine.Spy;
+    resetVarListDuplicateResolutionState: jasmine.Spy;
   };
 
   let dialog: FakeMatDialog;
@@ -76,7 +77,8 @@ describe('SchemerComponent', () => {
     };
 
     schemerFacade = {
-      tryResolveVarListDuplicates: jasmine.createSpy('tryResolveVarListDuplicates').and.returnValue(false)
+      tryResolveVarListDuplicates: jasmine.createSpy('tryResolveVarListDuplicates').and.returnValue(false),
+      resetVarListDuplicateResolutionState: jasmine.createSpy('resetVarListDuplicateResolutionState')
     };
 
     component = new SchemerComponent(
@@ -185,6 +187,13 @@ describe('SchemerComponent', () => {
     expect(emitSpy).toHaveBeenCalledWith(schemerService.codingScheme);
     changes$.complete();
   }));
+
+  it('ngOnDestroy should reset duplicate resolution state', () => {
+    component.ngOnDestroy();
+
+    expect(schemerFacade.resetVarListDuplicateResolutionState)
+      .toHaveBeenCalled();
+  });
 
   it('updateVariableLists should remove orphan empty BASE variables not in varList', () => {
     const orphanEmptyBase: VariableCodingData = {

--- a/projects/ngx-coding-components/src/lib/schemer/schemer.component.ts
+++ b/projects/ngx-coding-components/src/lib/schemer/schemer.component.ts
@@ -786,5 +786,6 @@ export class SchemerComponent implements OnDestroy {
 
   ngOnDestroy(): void {
     if (this.varCodingChangedSubscription !== null) this.varCodingChangedSubscription.unsubscribe();
+    this.schemerFacade.resetVarListDuplicateResolutionState();
   }
 }

--- a/projects/ngx-coding-components/src/lib/services/schemer-facade.service.spec.ts
+++ b/projects/ngx-coding-components/src/lib/services/schemer-facade.service.spec.ts
@@ -149,6 +149,86 @@ describe('SchemerFacadeService', () => {
     expect(dialog.open).toHaveBeenCalledTimes(1);
   });
 
+  it('resetVarListDuplicateResolutionState should allow the same dismissed conflict to open again', () => {
+    const service = createService();
+
+    schemerService.setVarList([
+      { id: 'A', alias: 'A' } as never,
+      { id: 'A', alias: 'B' } as never
+    ]);
+
+    const afterClosed$ = new Subject<unknown>();
+    (dialog.open as jasmine.Spy).and.returnValue({
+      afterClosed: () => afterClosed$.asObservable()
+    });
+
+    expect(service.tryResolveVarListDuplicates()).toBeTrue();
+    afterClosed$.next(null);
+
+    expect(service.tryResolveVarListDuplicates()).toBeTrue();
+    expect(dialog.open).toHaveBeenCalledTimes(1);
+
+    service.resetVarListDuplicateResolutionState();
+
+    expect(service.tryResolveVarListDuplicates()).toBeTrue();
+    expect(dialog.open).toHaveBeenCalledTimes(2);
+  });
+
+  it('resetVarListDuplicateResolutionState should clear an in-progress dialog state', () => {
+    const service = createService();
+
+    schemerService.setVarList([
+      { id: 'A', alias: 'A' } as never,
+      { id: 'A', alias: 'B' } as never
+    ]);
+
+    (dialog.open as jasmine.Spy).and.returnValue({
+      afterClosed: () => new Subject<unknown>().asObservable()
+    });
+
+    expect(service.tryResolveVarListDuplicates()).toBeTrue();
+    expect(service.tryResolveVarListDuplicates()).toBeTrue();
+    expect(dialog.open).toHaveBeenCalledTimes(1);
+
+    service.resetVarListDuplicateResolutionState();
+
+    expect(service.tryResolveVarListDuplicates()).toBeTrue();
+    expect(dialog.open).toHaveBeenCalledTimes(2);
+  });
+
+  it('resetVarListDuplicateResolutionState should ignore stale dialog close callbacks', () => {
+    const service = createService();
+
+    schemerService.setVarList([
+      { id: 'A', alias: 'A' } as never,
+      { id: 'A', alias: 'B' } as never
+    ]);
+
+    const staleAfterClosed$ = new Subject<unknown>();
+    const nextAfterClosed$ = new Subject<unknown>();
+    const staleDialogRef = {
+      close: jasmine.createSpy('close'),
+      afterClosed: () => staleAfterClosed$.asObservable()
+    };
+    const nextDialogRef = {
+      close: jasmine.createSpy('close'),
+      afterClosed: () => nextAfterClosed$.asObservable()
+    };
+    (dialog.open as jasmine.Spy).and.returnValues(
+      staleDialogRef,
+      nextDialogRef
+    );
+
+    expect(service.tryResolveVarListDuplicates()).toBeTrue();
+
+    service.resetVarListDuplicateResolutionState();
+    staleAfterClosed$.next(null);
+
+    expect(service.tryResolveVarListDuplicates()).toBeTrue();
+    expect(staleDialogRef.close).toHaveBeenCalled();
+    expect(dialog.open).toHaveBeenCalledTimes(2);
+  });
+
   it('tryResolveVarListDuplicates should not mutate varList or codingScheme when dialog closes', () => {
     const service = createService();
 

--- a/projects/ngx-coding-components/src/lib/services/schemer-facade.service.ts
+++ b/projects/ngx-coding-components/src/lib/services/schemer-facade.service.ts
@@ -12,8 +12,7 @@ export class SchemerFacadeService {
   private resolvingVarListDuplicates = false;
   private dismissedVarListDuplicateSignature: string | null = null;
   private varListDuplicateResolutionGeneration = 0;
-  private varListDuplicateDialogRef:
-    MatDialogRef<ResolveVarListDuplicatesDialogComponent> | null = null;
+  private varListDuplicateDialogRef: MatDialogRef<ResolveVarListDuplicatesDialogComponent> | null = null;
 
   constructor(
     private schemerService: SchemerService,

--- a/projects/ngx-coding-components/src/lib/services/schemer-facade.service.ts
+++ b/projects/ngx-coding-components/src/lib/services/schemer-facade.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { MatDialog } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { VariableInfo } from '@iqbspecs/variable-info/variable-info.interface';
 import { SchemerService } from './schemer.service';
 import { ResolveVarListDuplicatesDialogComponent } from '../dialogs/resolve-varlist-duplicates-dialog.component';
@@ -11,6 +11,9 @@ import { getVarListConflictAnalysis } from './schemer-varlist-validation';
 export class SchemerFacadeService {
   private resolvingVarListDuplicates = false;
   private dismissedVarListDuplicateSignature: string | null = null;
+  private varListDuplicateResolutionGeneration = 0;
+  private varListDuplicateDialogRef:
+    MatDialogRef<ResolveVarListDuplicatesDialogComponent> | null = null;
 
   constructor(
     private schemerService: SchemerService,
@@ -19,6 +22,15 @@ export class SchemerFacadeService {
 
   setVarList(value: VariableInfo[]): void {
     this.schemerService.setVarList(value);
+  }
+
+  resetVarListDuplicateResolutionState(): void {
+    this.varListDuplicateResolutionGeneration += 1;
+    this.resolvingVarListDuplicates = false;
+    this.dismissedVarListDuplicateSignature = null;
+    const dialogRef = this.varListDuplicateDialogRef;
+    this.varListDuplicateDialogRef = null;
+    dialogRef?.close?.();
   }
 
   tryResolveVarListDuplicates(): boolean {
@@ -45,6 +57,7 @@ export class SchemerFacadeService {
 
     this.resolvingVarListDuplicates = true;
 
+    const generation = this.varListDuplicateResolutionGeneration;
     const dialogRef = this.dialog.open(
       ResolveVarListDuplicatesDialogComponent,
       {
@@ -55,8 +68,12 @@ export class SchemerFacadeService {
         }
       }
     );
+    this.varListDuplicateDialogRef = dialogRef;
 
     dialogRef.afterClosed().subscribe(() => {
+      if (generation !== this.varListDuplicateResolutionGeneration) return;
+
+      this.varListDuplicateDialogRef = null;
       this.resolvingVarListDuplicates = false;
       const currentAnalysis = getVarListConflictAnalysis(
         this.schemerService.varList || []


### PR DESCRIPTION
## Summary

- reset duplicate-conflict guard state when the Schemer component is destroyed
- invalidate stale duplicate-dialog close callbacks so old dialogs cannot reapply dismissed state after tab reopen
- add regression coverage for dismissed, in-progress, and stale dialog lifecycle cases

## Validation

- `npm run test:cc` (283 SUCCESS)

Closes #154