### PR TITLE
Basisvariablen vor versehentlichem Löschen schützen

### DIFF
--- a/projects/ngx-coding-components/src/lib/schemer/schemer.component.spec.ts
+++ b/projects/ngx-coding-components/src/lib/schemer/schemer.component.spec.ts
@@ -38,6 +38,7 @@ describe('SchemerComponent', () => {
     setVarList: (v: unknown) => void;
     setUserRole: (v: unknown) => void;
     checkRenamedVarAliasOk: (alias: string, id?: string) => boolean;
+    isProtectedBaseVariable: (varCoding: VariableCodingData | null | undefined) => boolean;
   };
 
   let schemerFacade: {
@@ -73,7 +74,12 @@ describe('SchemerComponent', () => {
       setUserRole: (v: unknown) => {
         schemerService.userRole = v as unknown as never;
       },
-      checkRenamedVarAliasOk: () => true
+      checkRenamedVarAliasOk: () => true,
+      isProtectedBaseVariable: (varCoding: VariableCodingData | null | undefined) => (
+        !!varCoding &&
+        varCoding.sourceType === 'BASE' &&
+        schemerService.varList.some(v => v.id === varCoding.id && v.type !== 'no-value')
+      )
     };
 
     schemerFacade = {
@@ -818,6 +824,47 @@ describe('SchemerComponent', () => {
     expect(emitSpy).toHaveBeenCalled();
   });
 
+  it('deleteVarScheme should not offer or remove protected external BASE variables', () => {
+    const emitSpy = spyOn(component.codingSchemeChanged, 'emit');
+    const updateSpy = spyOn(component, 'updateVariableLists');
+
+    schemerService.setVarList([
+      {
+        id: 'v1',
+        alias: 'A',
+        type: 'integer',
+        format: '',
+        multiple: false,
+        nullable: false,
+        values: [],
+        valuePositionLabels: []
+      } as unknown as VariableInfo
+    ]);
+    schemerService.setCodingScheme({
+      variableCodings: [
+        {
+          id: 'v1', alias: 'A', sourceType: 'BASE', codes: []
+        } as unknown as VariableCodingData,
+        {
+          id: 'd1', alias: 'D', sourceType: 'DERIVE', codes: []
+        } as unknown as VariableCodingData
+      ]
+    } as unknown as never);
+
+    selectVariableDialog.afterClosedValue = ['A'];
+
+    component.deleteVarScheme();
+
+    const dialogData = selectVariableDialog.open.calls.mostRecent().args[1]
+      .data as { variables: VariableCodingData[] };
+    expect(dialogData.variables.map(v => v.alias)).toEqual(['D']);
+
+    const scheme = schemerService.codingScheme as unknown as { variableCodings: VariableCodingData[] };
+    expect(scheme.variableCodings.some(v => v.id === 'v1')).toBeTrue();
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(emitSpy).not.toHaveBeenCalled();
+  });
+
   it('copyVarScheme should clone selected coding into target variable and emit', () => {
     const emitSpy = spyOn(component.codingSchemeChanged, 'emit');
     const updateSpy = spyOn(component, 'updateVariableLists');
@@ -874,6 +921,42 @@ describe('SchemerComponent', () => {
     const scheme = schemerService.codingScheme as unknown as { variableCodings: VariableCodingData[] };
     expect(scheme.variableCodings.find(v => v.id === 'n1')?.sourceType).toBe('BASE');
     expect(schemerService.varList.some(v => v.id === 'n1')).toBeTrue();
+    expect(updateSpy).toHaveBeenCalled();
+    expect(emitSpy).toHaveBeenCalled();
+  });
+
+  it('activateBaseNoValueVars should not duplicate an existing varList entry', () => {
+    const emitSpy = spyOn(component.codingSchemeChanged, 'emit');
+    const updateSpy = spyOn(component, 'updateVariableLists');
+
+    schemerService.setCodingScheme({
+      variableCodings: [
+        {
+          id: 'radio_1', alias: '01', sourceType: 'BASE_NO_VALUE', codes: []
+        } as unknown as VariableCodingData
+      ]
+    } as unknown as never);
+    schemerService.setVarList([
+      {
+        id: 'radio_1',
+        alias: '01',
+        type: 'integer',
+        format: '',
+        multiple: false,
+        nullable: false,
+        values: [],
+        valuePositionLabels: []
+      } as unknown as VariableInfo
+    ]);
+
+    selectVariableDialog.afterClosedValue = ['01'];
+    spyOn(CodingSchemeFactory, 'validate').and.returnValue([] as unknown as CodingSchemeProblem[]);
+
+    component.activateBaseNoValueVars();
+
+    const scheme = schemerService.codingScheme as unknown as { variableCodings: VariableCodingData[] };
+    expect(scheme.variableCodings.find(v => v.id === 'radio_1')?.sourceType).toBe('BASE');
+    expect(schemerService.varList.filter(v => v.id === 'radio_1').length).toBe(1);
     expect(updateSpy).toHaveBeenCalled();
     expect(emitSpy).toHaveBeenCalled();
   });

--- a/projects/ngx-coding-components/src/lib/schemer/schemer.component.ts
+++ b/projects/ngx-coding-components/src/lib/schemer/schemer.component.ts
@@ -532,7 +532,8 @@ export class SchemerComponent implements OnDestroy {
         title: this.tr('schemer.delete.title'),
         prompt: this.tr('schemer.delete.prompt'),
         variables: this.schemerService.codingScheme.variableCodings.filter(
-          c => c.sourceType !== 'BASE_NO_VALUE'
+          c => c.sourceType !== 'BASE_NO_VALUE' &&
+            !this.schemerService.isProtectedBaseVariable(c)
         ),
         selectedVariable: this.selectedCoding$.getValue(),
         codingStatus: this.codingStatus,
@@ -549,14 +550,16 @@ export class SchemerComponent implements OnDestroy {
         let changed = false;
         if (variables && variables.length > 0) {
           if (this.schemerService && this.schemerService.codingScheme) {
+            const oldLength =
+              this.schemerService.codingScheme.variableCodings.length;
             this.schemerService.codingScheme.variableCodings =
               this.schemerService.codingScheme.variableCodings.filter(
-                c => !variables.includes(c.alias || c.id)
+                c => this.schemerService.isProtectedBaseVariable(c) ||
+                  !variables.includes(c.alias || c.id)
               );
-            changed = true;
-            this.selectedCoding$.next(null);
-            this.updateVariableLists();
-            this.codingSchemeChanged.emit(this.schemerService.codingScheme);
+            changed =
+              this.schemerService.codingScheme.variableCodings.length !==
+              oldLength;
           }
           if (changed) {
             this.updateVariableLists();
@@ -657,16 +660,20 @@ export class SchemerComponent implements OnDestroy {
                 this.schemerService.codingScheme.variableCodings.push(
                   targetCoding
                 );
-                this.schemerService.varList.push({
-                  id: targetCoding.id,
-                  alias: targetCoding.alias || targetCoding.id,
-                  type: 'string',
-                  format: '',
-                  multiple: true,
-                  nullable: true,
-                  values: [],
-                  valuePositionLabels: []
-                });
+                if (!this.schemerService.varList.some(
+                  vi => vi.id === targetCoding.id
+                )) {
+                  this.schemerService.varList.push({
+                    id: targetCoding.id,
+                    alias: targetCoding.alias || targetCoding.id,
+                    type: 'string',
+                    format: '',
+                    multiple: true,
+                    nullable: true,
+                    values: [],
+                    valuePositionLabels: []
+                  });
+                }
                 changed = true;
               }
             }

--- a/projects/ngx-coding-components/src/lib/services/schemer.service.ts
+++ b/projects/ngx-coding-components/src/lib/services/schemer.service.ts
@@ -244,4 +244,9 @@ export class SchemerService {
     }
     return [];
   }
+
+  isProtectedBaseVariable(varCoding: VariableCodingData | null | undefined): boolean {
+    if (!varCoding || varCoding.sourceType !== 'BASE') return false;
+    return this.varList.some(v => v.id === varCoding.id && v.type !== 'no-value');
+  }
 }

--- a/projects/ngx-coding-components/src/lib/var-coding/var-coding.component.spec.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/var-coding.component.spec.ts
@@ -22,6 +22,7 @@ describe('VarCodingComponent', () => {
   let sortCodesSpy: jasmine.Spy;
   let getAliasSpy: jasmine.Spy;
   let setCodingToTextModeSpy: jasmine.Spy;
+  let isProtectedBaseVariableSpy: jasmine.Spy;
 
   beforeEach(async () => {
     dialogOpenSpy = jasmine.createSpy('open').and.returnValue({
@@ -34,6 +35,7 @@ describe('VarCodingComponent', () => {
     sortCodesSpy = jasmine.createSpy('sortCodes');
     getAliasSpy = jasmine.createSpy('getVariableAliasById').and.callFake((id: string) => `${id}_ALIAS`);
     setCodingToTextModeSpy = jasmine.createSpy('setCodingToTextMode');
+    isProtectedBaseVariableSpy = jasmine.createSpy('isProtectedBaseVariable').and.returnValue(false);
 
     await TestBed.configureTestingModule({
       imports: [
@@ -63,7 +65,8 @@ describe('VarCodingComponent', () => {
             pasteSingleCode: pasteSpy,
             sortCodes: sortCodesSpy,
             getVariableAliasById: getAliasSpy,
-            setCodingToTextMode: setCodingToTextModeSpy
+            setCodingToTextMode: setCodingToTextModeSpy,
+            isProtectedBaseVariable: isProtectedBaseVariableSpy
           }
         }
       ]
@@ -375,6 +378,44 @@ describe('VarCodingComponent', () => {
     };
     component.deactivateBaseVar();
     expect(dialogOpenSpy).not.toHaveBeenCalled();
+  });
+
+  it('deactivateBaseVar should allow protected external BASE variables to become no-value', () => {
+    const emitSpy = spyOn(component.varCodingChanged, 'emit');
+    const noValue = { id: 'b1', sourceType: 'BASE_NO_VALUE', codes: [] } as unknown as VariableCodingData;
+    const createSpy = spyOn(CodingFactory, 'createBaseCodingVariable').and.returnValue(noValue as never);
+
+    component.varCoding = {
+      id: 'b1',
+      alias: 'B1',
+      sourceType: 'BASE',
+      codes: []
+    } as unknown as VariableCodingData;
+
+    (schemerService as unknown as { codingScheme: { variableCodings: VariableCodingData[] } }).codingScheme = {
+      variableCodings: [
+        component.varCoding,
+        {
+          id: 'b2', alias: 'B2', sourceType: 'BASE', codes: []
+        } as unknown as VariableCodingData
+      ]
+    };
+
+    isProtectedBaseVariableSpy.and.returnValue(true);
+    dialogOpenSpy.calls.reset();
+    dialogOpenSpy.and.returnValue({ afterClosed: () => of(true) });
+
+    component.deactivateBaseVar();
+
+    const scheme = (schemerService as unknown as
+      { codingScheme: { variableCodings: VariableCodingData[] } }).codingScheme;
+    expect(dialogOpenSpy).toHaveBeenCalled();
+    expect(createSpy).toHaveBeenCalledWith('b1', 'BASE_NO_VALUE');
+    expect(scheme.variableCodings.some(v => v.id === 'b1' && v.sourceType === 'BASE')).toBeFalse();
+    expect(scheme.variableCodings.some(v => v.id === 'b1' &&
+      (v as unknown as { sourceType: string }).sourceType === 'BASE_NO_VALUE')).toBeTrue();
+    expect(emitSpy).toHaveBeenCalledWith(noValue);
+    expect(component.varCoding).toBeNull();
   });
 
   it('deactivateBaseVar should replace BASE var with no-value coding when confirmed', () => {


### PR DESCRIPTION
## Zusammenfassung
- Verhindert doppelte lokale `varList`-Einträge beim Reaktivieren von `BASE_NO_VALUE`-Variablen.
- Schützt echte externe `BASE`-Variablen vor versehentlichem Löschen.
- Lässt das bewusste Deaktivieren von `BASE` zu `BASE_NO_VALUE` weiterhin zu.
- Ergänzt Regressionstests für Löschschutz, Reaktivierung und erlaubtes Deaktivieren.

## Hintergrund
Bei Issue #171 kann eine echte Unit-Basisvariable im Coding-Scheme als `BASE_NO_VALUE` landen. Beim Reaktivieren wurde bisher zusätzlich ein lokaler `varList`-Eintrag erzeugt, obwohl dieselbe Variable bereits aus der externen Variablenliste kam. Außerdem konnten echte externe Basisvariablen im Löschdialog entfernt werden.

## Tests
- `npm run test:cc`
- `npm run lint`

Referenz: #171
