### PR TITLE
Diagnose varlist alias/id collisions

### DIFF
--- a/projects/ngx-coding-components/src/lib/dialogs/resolve-varlist-duplicates-dialog.component.spec.ts
+++ b/projects/ngx-coding-components/src/lib/dialogs/resolve-varlist-duplicates-dialog.component.spec.ts
@@ -50,6 +50,33 @@ describe('ResolveVarListDuplicatesDialogComponent', () => {
     expect(component.invalidAliasCount).toBeGreaterThan(0);
   });
 
+  it('should allow generated ids and aliases with hyphens', () => {
+    const { component } = createComponent({
+      varList: [
+        { id: 'likert-row_4', alias: 'Item-01' },
+        { id: 'likert-row_5', alias: 'Item-02' }
+      ]
+    });
+
+    expect(component.hasProblems).toBeFalse();
+    expect(component.invalidIdCount).toBe(0);
+    expect(component.invalidAliasCount).toBe(0);
+  });
+
+  it('should mark alias/id collisions', () => {
+    const { component } = createComponent({
+      varList: [
+        { id: 'likert-row_4', alias: '01a' },
+        { id: '01a', alias: '05a' }
+      ]
+    });
+
+    expect(component.hasProblems).toBeTrue();
+    expect(component.aliasIdCollisionValues).toEqual(['01A']);
+    expect(component.isAliasIdCollisionAlias('01a')).toBeTrue();
+    expect(component.isAliasIdCollisionId('01a')).toBeTrue();
+  });
+
   it('should not mutate the input varList', () => {
     const original = [
       { id: 'AA', alias: 'AA' },

--- a/projects/ngx-coding-components/src/lib/dialogs/resolve-varlist-duplicates-dialog.component.ts
+++ b/projects/ngx-coding-components/src/lib/dialogs/resolve-varlist-duplicates-dialog.component.ts
@@ -10,7 +10,8 @@ import { VariableInfo } from '@iqbspecs/variable-info/variable-info.interface';
 import { MatButton } from '@angular/material/button';
 import {
   getVarListConflictAnalysis,
-  isInvalidVarListName
+  isInvalidVarListAlias,
+  isInvalidVarListId
 } from '../services/schemer-varlist-validation';
 
 export interface ResolveVarListDuplicatesDialogData {
@@ -19,11 +20,11 @@ export interface ResolveVarListDuplicatesDialogData {
 
 @Component({
   template: `
-    <h1 mat-dialog-title>Doppelte Variablen-IDs/Aliase</h1>
+    <h1 mat-dialog-title>Problematische Variablen-IDs/Aliase</h1>
 
     <mat-dialog-content>
       <div style="margin-bottom: 10px;">
-        Die Variablenliste enthält doppelte oder ungültige IDs/Aliase.
+        Die Variablenliste enthält doppelte, ungültige oder kollidierende IDs/Aliase.
         Bitte korrigiere die Variablenliste und lade den Schemer neu.
       </div>
 
@@ -40,6 +41,8 @@ export interface ResolveVarListDuplicatesDialogData {
         <div><b>Doppelte IDs:</b> {{ duplicateIdValues.join(', ') }}</div>
         } @if (duplicateAliasValues.length > 0) {
         <div><b>Doppelte Aliase:</b> {{ duplicateAliasValues.join(', ') }}</div>
+        } @if (aliasIdCollisionValues.length > 0) {
+        <div><b>Alias entspricht anderer ID:</b> {{ aliasIdCollisionValues.join(', ') }}</div>
         } @if (invalidIdCount > 0) {
         <div><b>Ungültige IDs:</b> {{ invalidIdCount }}</div>
         } @if (invalidAliasCount > 0) {
@@ -53,6 +56,7 @@ export interface ResolveVarListDuplicatesDialogData {
         <div
           style="flex: 1;"
           [class.duplicate-field]="isDuplicateId(v.id)"
+          [class.alias-id-field]="isAliasIdCollisionId(v.id)"
           [class.invalid-field]="isInvalidId(v.id)"
         >
           <b>ID:</b> {{ v.id || '-' }}
@@ -60,6 +64,7 @@ export interface ResolveVarListDuplicatesDialogData {
         <div
           style="flex: 1;"
           [class.duplicate-field]="isDuplicateAlias(v.alias || v.id)"
+          [class.alias-id-field]="isAliasIdCollisionAlias(v.alias || v.id)"
           [class.invalid-field]="isInvalidAlias(v.alias || v.id)"
         >
           <b>Alias:</b> {{ v.alias || v.id || '-' }}
@@ -80,6 +85,7 @@ export interface ResolveVarListDuplicatesDialogData {
   `,
   styles: [
     '.duplicate-field { outline: 2px solid #b00020; outline-offset: 2px; border-radius: 3px; padding: 4px; }',
+    '.alias-id-field { outline: 2px solid #c2185b; outline-offset: 2px; border-radius: 3px; padding: 4px; }',
     '.invalid-field { outline: 2px solid #ff6f00; outline-offset: 2px; border-radius: 3px; padding: 4px; }'
   ],
   standalone: true,
@@ -98,9 +104,12 @@ export class ResolveVarListDuplicatesDialogComponent {
 
   private duplicateIds = new Set<string>();
   private duplicateAliases = new Set<string>();
+  private aliasIdCollisionAliases = new Set<string>();
+  private aliasIdCollisionIds = new Set<string>();
 
   duplicateIdValues: string[] = [];
   duplicateAliasValues: string[] = [];
+  aliasIdCollisionValues: string[] = [];
   invalidIdCount = 0;
   invalidAliasCount = 0;
 
@@ -117,8 +126,11 @@ export class ResolveVarListDuplicatesDialogComponent {
 
     this.duplicateIds = analysis.duplicateIds;
     this.duplicateAliases = analysis.duplicateAliases;
+    this.aliasIdCollisionAliases = analysis.aliasIdCollisionAliases;
+    this.aliasIdCollisionIds = analysis.aliasIdCollisionIds;
     this.duplicateIdValues = analysis.duplicateIdValues;
     this.duplicateAliasValues = analysis.duplicateAliasValues;
+    this.aliasIdCollisionValues = analysis.aliasIdCollisionValues;
     this.invalidIdCount = analysis.invalidIdCount;
     this.invalidAliasCount = analysis.invalidAliasCount;
     this.hasProblems = analysis.hasProblems;
@@ -126,13 +138,16 @@ export class ResolveVarListDuplicatesDialogComponent {
     if (this.hasProblems) {
       const problems: string[] = [];
       if (analysis.hasInvalid) {
-        problems.push('Ungültige ID/Alias (nur [a-zA-Z0-9_], min. 2 Zeichen)');
+        problems.push('Ungültige ID/Alias');
       }
       if (analysis.hasDuplicateId) {
         problems.push('Doppelte IDs');
       }
       if (analysis.hasDuplicateAlias) {
         problems.push('Doppelte Aliase');
+      }
+      if (analysis.hasAliasIdCollision) {
+        problems.push('Alias entspricht anderer ID');
       }
       this.statusText = problems.join(' | ');
     } else {
@@ -150,11 +165,18 @@ export class ResolveVarListDuplicatesDialogComponent {
     return !!key && this.duplicateAliases.has(key);
   }
 
-  isInvalidId = isInvalidVarListName;
-
-  isInvalidAlias(value: string | null | undefined): boolean {
-    return this.isInvalidId(value);
+  isAliasIdCollisionId(value: string | null | undefined): boolean {
+    const key = (value || '').trim().toUpperCase();
+    return !!key && this.aliasIdCollisionIds.has(key);
   }
+
+  isAliasIdCollisionAlias(value: string | null | undefined): boolean {
+    const key = (value || '').trim().toUpperCase();
+    return !!key && this.aliasIdCollisionAliases.has(key);
+  }
+
+  isInvalidId = isInvalidVarListId;
+  isInvalidAlias = isInvalidVarListAlias;
 
   close(): void {
     this.dialogRef.close();

--- a/projects/ngx-coding-components/src/lib/services/schemer-varlist-validation.spec.ts
+++ b/projects/ngx-coding-components/src/lib/services/schemer-varlist-validation.spec.ts
@@ -1,6 +1,8 @@
 import { VariableInfo } from '@iqbspecs/variable-info/variable-info.interface';
 import {
   getVarListConflictAnalysis,
+  isInvalidVarListAlias,
+  isInvalidVarListId,
   isInvalidVarListName
 } from './schemer-varlist-validation';
 
@@ -10,6 +12,18 @@ describe('schemer-varlist-validation', () => {
     expect(isInvalidVarListName('A')).toBeTrue();
     expect(isInvalidVarListName('A B')).toBeTrue();
     expect(isInvalidVarListName('')).toBeTrue();
+  });
+
+  it('isInvalidVarListId should allow generated ids with hyphens', () => {
+    expect(isInvalidVarListId('likert-row_4')).toBeFalse();
+    expect(isInvalidVarListId('A B')).toBeTrue();
+    expect(isInvalidVarListId('A')).toBeTrue();
+  });
+
+  it('isInvalidVarListAlias should allow generated aliases with hyphens', () => {
+    expect(isInvalidVarListAlias('Alias_1')).toBeFalse();
+    expect(isInvalidVarListAlias('Alias-1')).toBeFalse();
+    expect(isInvalidVarListAlias('A B')).toBeTrue();
   });
 
   it('getVarListConflictAnalysis should detect duplicate ids and aliases', () => {
@@ -38,6 +52,21 @@ describe('schemer-varlist-validation', () => {
     expect(analysis.invalidAliasCount).toBe(1);
   });
 
+  it('getVarListConflictAnalysis should detect alias/id collisions', () => {
+    const analysis = getVarListConflictAnalysis([
+      { id: 'likert-row_4', alias: '01a' },
+      { id: '01a', alias: '05a' },
+      { id: 'likert-row_5', alias: '01b' },
+      { id: '01b', alias: '05b' }
+    ] as VariableInfo[]);
+
+    expect(analysis.hasProblems).toBeTrue();
+    expect(analysis.hasAliasIdCollision).toBeTrue();
+    expect(analysis.aliasIdCollisionValues).toEqual(['01A', '01B']);
+    expect(analysis.invalidIdCount).toBe(0);
+    expect(analysis.invalidAliasCount).toBe(0);
+  });
+
   it('getVarListConflictAnalysis should provide a stable normalized signature', () => {
     const analysis = getVarListConflictAnalysis([
       { id: ' aa ', alias: ' Alias ' },
@@ -49,7 +78,7 @@ describe('schemer-varlist-validation', () => {
 
   it('getVarListConflictAnalysis should report no problems for valid unique variables', () => {
     const analysis = getVarListConflictAnalysis([
-      { id: 'AA', alias: 'AliasAA' },
+      { id: 'likert-row_4', alias: 'Alias-AA' },
       { id: 'BB', alias: 'AliasBB' }
     ] as VariableInfo[]);
 

--- a/projects/ngx-coding-components/src/lib/services/schemer-varlist-validation.ts
+++ b/projects/ngx-coding-components/src/lib/services/schemer-varlist-validation.ts
@@ -1,16 +1,22 @@
 import { VariableInfo } from '@iqbspecs/variable-info/variable-info.interface';
 import { VARIABLE_NAME_CHECK_PATTERN } from './schemer.service';
 
+const VARIABLE_ID_CHECK_PATTERN = /^[a-zA-Z0-9_-]{2,}$/;
+
 export type VarListConflictAnalysis = {
   signature: string;
   duplicateIds: Set<string>;
   duplicateAliases: Set<string>;
+  aliasIdCollisionAliases: Set<string>;
+  aliasIdCollisionIds: Set<string>;
   duplicateIdValues: string[];
   duplicateAliasValues: string[];
+  aliasIdCollisionValues: string[];
   invalidIdCount: number;
   invalidAliasCount: number;
   hasDuplicateId: boolean;
   hasDuplicateAlias: boolean;
+  hasAliasIdCollision: boolean;
   hasInvalid: boolean;
   hasProblems: boolean;
 };
@@ -38,6 +44,15 @@ export const isInvalidVarListName = (
   return !name || !VARIABLE_NAME_CHECK_PATTERN.test(name);
 };
 
+export const isInvalidVarListId = (
+  value: string | null | undefined
+): boolean => {
+  const name = normaliseName(value);
+  return !name || !VARIABLE_ID_CHECK_PATTERN.test(name);
+};
+
+export const isInvalidVarListAlias = isInvalidVarListId;
+
 export const getVarListConflictAnalysis = (
   varList: VariableInfo[] = []
 ): VarListConflictAnalysis => {
@@ -61,27 +76,48 @@ export const getVarListConflictAnalysis = (
       .map(([k]) => k)
   );
 
-  const invalidIdCount = varList.filter(v => isInvalidVarListName(v.id))
+  const idKeys = new Set(
+    varList.map(v => normaliseKey(v.id)).filter(v => !!v)
+  );
+  const aliasIdCollisionAliases = new Set<string>();
+  const aliasIdCollisionIds = new Set<string>();
+  varList.forEach(v => {
+    const idKey = normaliseKey(v.id);
+    const aliasKey = normaliseKey(v.alias || v.id);
+    if (aliasKey && idKey && aliasKey !== idKey && idKeys.has(aliasKey)) {
+      aliasIdCollisionAliases.add(aliasKey);
+      aliasIdCollisionIds.add(aliasKey);
+    }
+  });
+
+  const invalidIdCount = varList.filter(v => isInvalidVarListId(v.id))
     .length;
   const invalidAliasCount = varList.filter(v => (
-    isInvalidVarListName(v.alias || v.id)
+    isInvalidVarListAlias(v.alias || v.id)
   )).length;
 
   const hasDuplicateId = duplicateIds.size > 0;
   const hasDuplicateAlias = duplicateAliases.size > 0;
+  const hasAliasIdCollision = aliasIdCollisionAliases.size > 0;
   const hasInvalid = invalidIdCount > 0 || invalidAliasCount > 0;
 
   return {
     signature,
     duplicateIds,
     duplicateAliases,
+    aliasIdCollisionAliases,
+    aliasIdCollisionIds,
     duplicateIdValues: Array.from(duplicateIds.values()).sort(),
     duplicateAliasValues: Array.from(duplicateAliases.values()).sort(),
+    aliasIdCollisionValues: Array.from(aliasIdCollisionAliases.values())
+      .sort(),
     invalidIdCount,
     invalidAliasCount,
     hasDuplicateId,
     hasDuplicateAlias,
+    hasAliasIdCollision,
     hasInvalid,
-    hasProblems: hasDuplicateId || hasDuplicateAlias || hasInvalid
+    hasProblems: hasDuplicateId || hasDuplicateAlias ||
+      hasAliasIdCollision || hasInvalid
   };
 };


### PR DESCRIPTION
## Summary
- allow generated variable IDs and aliases with hyphens in the varlist diagnostics
- detect aliases that collide with another variable ID as a dedicated conflict type
- show alias/ID collisions explicitly in the varlist problem dialog

## Context
Refs #168

The CMC example contains generated names such as `likert-row_4` and alias/ID collisions such as alias `01a` colliding with another variable ID `01a`. The diagnostics should not report generated hyphenated names as invalid; instead they should surface the actual alias/ID collision.

## Validation
- `npx eslint -c .eslintrc.cjs projects/ngx-coding-components/src/lib/services/schemer-varlist-validation.ts projects/ngx-coding-components/src/lib/services/schemer-varlist-validation.spec.ts projects/ngx-coding-components/src/lib/dialogs/resolve-varlist-duplicates-dialog.component.ts projects/ngx-coding-components/src/lib/dialogs/resolve-varlist-duplicates-dialog.component.spec.ts`
- `npm run test:cc -- --include='projects/ngx-coding-components/src/lib/services/schemer-varlist-validation.spec.ts' --include='projects/ngx-coding-components/src/lib/dialogs/resolve-varlist-duplicates-dialog.component.spec.ts'`
