### PR TITLE
Prevent cyclic derive source selection

### DIFF
--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.spec.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.spec.ts
@@ -102,6 +102,89 @@ describe('EditSourceParametersDialog', () => {
     expect(dialog.selectedSources.value).toEqual(['v2']);
   });
 
+  it('updatePossibleNewSources should exclude direct descendants of the current variable', () => {
+    const dialog = createDialog({
+      selfId: 'd1',
+      selfAlias: 'D1',
+      codingScheme: {
+        variableCodings: [
+          {
+            id: 'base1', alias: 'BASE1', sourceType: 'BASE'
+          },
+          {
+            id: 'd1', alias: 'D1', sourceType: 'DERIVE', deriveSources: ['base1']
+          },
+          {
+            id: 'd2', alias: 'D2', sourceType: 'DERIVE', deriveSources: ['d1']
+          },
+          {
+            id: 'd3', alias: 'D3', sourceType: 'DERIVE', deriveSources: ['base1']
+          }
+        ]
+      }
+    });
+
+    expect(Array.from(dialog.possibleNewSources.keys()).sort()).toEqual([
+      'base1',
+      'd3'
+    ]);
+  });
+
+  it('updatePossibleNewSources should exclude indirect descendants of the current variable', () => {
+    const dialog = createDialog({
+      selfId: 'd1',
+      selfAlias: 'D1',
+      codingScheme: {
+        variableCodings: [
+          {
+            id: 'base1', alias: 'BASE1', sourceType: 'BASE'
+          },
+          {
+            id: 'd1', alias: 'D1', sourceType: 'DERIVE', deriveSources: ['base1']
+          },
+          {
+            id: 'd2', alias: 'D2', sourceType: 'DERIVE', deriveSources: ['d1']
+          },
+          {
+            id: 'd3', alias: 'D3', sourceType: 'DERIVE', deriveSources: ['d2']
+          },
+          {
+            id: 'd4', alias: 'D4', sourceType: 'DERIVE', deriveSources: ['base1']
+          }
+        ]
+      }
+    });
+
+    expect(Array.from(dialog.possibleNewSources.keys()).sort()).toEqual([
+      'base1',
+      'd4'
+    ]);
+  });
+
+  it('updatePossibleNewSources should prune selected sources that would create a cycle', () => {
+    const dialog = createDialog({
+      selfId: 'd1',
+      selfAlias: 'D1',
+      deriveSources: ['base1', 'd2'],
+      codingScheme: {
+        variableCodings: [
+          {
+            id: 'base1', alias: 'BASE1', sourceType: 'BASE'
+          },
+          {
+            id: 'd1', alias: 'D1', sourceType: 'DERIVE', deriveSources: ['base1']
+          },
+          {
+            id: 'd2', alias: 'D2', sourceType: 'DERIVE', deriveSources: ['d1']
+          }
+        ]
+      }
+    });
+
+    expect(dialog.data.deriveSources).toEqual(['base1']);
+    expect(dialog.selectedSources.value).toEqual(['base1']);
+  });
+
   it('updatePossibleNewSources should return early when codingScheme is missing', () => {
     const dialog = createDialog({ codingScheme: null });
     dialog.possibleNewSources = new Map([['x', 'X']]);

--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.ts
@@ -317,13 +317,11 @@ export class EditSourceParametersDialog {
     if (!codingScheme) return;
 
     const validCodings = codingScheme.variableCodings.filter(
-      (variableCoding: VariableCodingData) => {
-        const aliasOrId = variableCoding.alias || variableCoding.id;
-        return (
-          aliasOrId !== this.data.selfAlias &&
-          variableCoding.sourceType !== 'BASE_NO_VALUE'
-        );
-      }
+      (variableCoding: VariableCodingData) => (
+        !this.isOwnVariable(variableCoding) &&
+        variableCoding.sourceType !== 'BASE_NO_VALUE' &&
+        !this.isDerivedFromSelf(variableCoding, codingScheme.variableCodings)
+      )
     );
 
     this.possibleNewSources = new Map(
@@ -333,6 +331,10 @@ export class EditSourceParametersDialog {
       ])
     );
 
+    const possibleSourceIds = new Set(this.possibleNewSources.keys());
+    this.data.deriveSources = this.data.deriveSources.filter(
+      sourceId => possibleSourceIds.has(sourceId)
+    );
     this.selectedSources.setValue(this.data.deriveSources);
     this.syncSolverTestValues();
   }
@@ -582,6 +584,79 @@ export class EditSourceParametersDialog {
     const sourceAlias = this.schemerService.getVariableAliasById(sourceId);
     return this.possibleNewSources.get(sourceId) ||
       (sourceAlias === '?' ? sourceId : sourceAlias);
+  }
+
+  private isOwnVariable(variableCoding: VariableCodingData): boolean {
+    return this.getSelfReferenceKeys([variableCoding]).some(
+      selfReference => (
+        variableCoding.id === selfReference ||
+        variableCoding.alias === selfReference
+      )
+    );
+  }
+
+  private isDerivedFromSelf(
+    variableCoding: VariableCodingData,
+    variableCodings: VariableCodingData[]
+  ): boolean {
+    const selfReferenceKeys = new Set(this.getSelfReferenceKeys(variableCodings));
+    if (selfReferenceKeys.size < 1) return false;
+
+    const codingsByReference = new Map<string, VariableCodingData>();
+    variableCodings.forEach(coding => {
+      codingsByReference.set(coding.id, coding);
+      if (coding.alias) codingsByReference.set(coding.alias, coding);
+    });
+
+    const visited = new Set<string>();
+    const sourcesToCheck = [...(variableCoding.deriveSources || [])];
+
+    while (sourcesToCheck.length > 0) {
+      const sourceReference = sourcesToCheck.pop();
+      if (sourceReference) {
+        if (selfReferenceKeys.has(sourceReference)) return true;
+
+        const sourceCoding = codingsByReference.get(sourceReference);
+        if (sourceCoding && !visited.has(sourceCoding.id)) {
+          if (
+            selfReferenceKeys.has(sourceCoding.id) ||
+            (sourceCoding.alias && selfReferenceKeys.has(sourceCoding.alias))
+          ) {
+            return true;
+          }
+
+          visited.add(sourceCoding.id);
+          sourcesToCheck.push(...(sourceCoding.deriveSources || []));
+        }
+      }
+    }
+
+    return false;
+  }
+
+  private getSelfReferenceKeys(
+    variableCodings: VariableCodingData[]
+  ): string[] {
+    const selfReferences = new Set<string>();
+    if (this.data.selfId) selfReferences.add(this.data.selfId);
+    if (this.data.selfAlias) selfReferences.add(this.data.selfAlias);
+
+    const selfCoding = variableCodings.find(
+      coding => (
+        (this.data.selfId && coding.id === this.data.selfId) ||
+        (this.data.selfAlias && (
+          coding.id === this.data.selfAlias ||
+          coding.alias === this.data.selfAlias
+        ))
+      )
+    );
+
+    if (selfCoding) {
+      selfReferences.add(selfCoding.id);
+      if (selfCoding.alias) selfReferences.add(selfCoding.alias);
+    }
+
+    return Array.from(selfReferences);
   }
 
   private static formatSolverTestValue(value: unknown): string {


### PR DESCRIPTION
## Summary

- prevent direct and indirect cyclic source selections in the source-parameter dialog
- prune already selected sources when they are no longer valid candidates
- add focused coverage for direct cycles, indirect cycles, and pruning

Closes #191.

Follow-up: #194 tracks central schema validation for imported or externally generated cyclic derivation graphs.

## Validation

- `npx eslint -c .eslintrc.cjs projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.ts projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.spec.ts`
- `npm run test:cc -- --include='**/edit-source-parameters-dialog.component.spec.ts'`
- `npm run test:cc`