### PR TITLE
Fix base no-value activation

### DIFF
--- a/projects/ngx-coding-components/src/lib/schemer/schemer.component.spec.ts
+++ b/projects/ngx-coding-components/src/lib/schemer/schemer.component.spec.ts
@@ -961,6 +961,48 @@ describe('SchemerComponent', () => {
     expect(emitSpy).toHaveBeenCalled();
   });
 
+  it('activateBaseNoValueVars should convert an existing no-value varList entry', () => {
+    const emitSpy = spyOn(component.codingSchemeChanged, 'emit');
+
+    schemerService.setCodingScheme({
+      variableCodings: [
+        {
+          id: 'radio_1', alias: '01', sourceType: 'BASE_NO_VALUE', codes: []
+        } as unknown as VariableCodingData
+      ]
+    } as unknown as never);
+    schemerService.setVarList([
+      {
+        id: 'radio_1',
+        alias: '01',
+        type: 'no-value',
+        format: '',
+        multiple: false,
+        nullable: false,
+        values: [],
+        valuePositionLabels: []
+      } as unknown as VariableInfo
+    ]);
+
+    selectVariableDialog.afterClosedValue = ['01'];
+
+    component.activateBaseNoValueVars();
+
+    const scheme = schemerService.codingScheme as unknown as {
+      variableCodings: VariableCodingData[];
+    };
+    const variableInfo = schemerService.varList.find(v => v.id === 'radio_1');
+    expect(scheme.variableCodings.find(v => v.id === 'radio_1')?.sourceType)
+      .toBe('BASE');
+    expect(variableInfo?.type).toBe('string');
+    expect(variableInfo?.multiple).toBeTrue();
+    expect(variableInfo?.nullable).toBeTrue();
+    expect(schemerService.varList.filter(v => v.id === 'radio_1').length)
+      .toBe(1);
+    expect(component.problems.some(p => p.type === 'INVALID_SOURCE')).toBeFalse();
+    expect(emitSpy).toHaveBeenCalled();
+  });
+
   it('showCodingScheme should do nothing when codingScheme is null', () => {
     schemerService.setCodingScheme(null);
     component.showCodingScheme();

--- a/projects/ngx-coding-components/src/lib/schemer/schemer.component.ts
+++ b/projects/ngx-coding-components/src/lib/schemer/schemer.component.ts
@@ -660,9 +660,19 @@ export class SchemerComponent implements OnDestroy {
                 this.schemerService.codingScheme.variableCodings.push(
                   targetCoding
                 );
-                if (!this.schemerService.varList.some(
+                const existingVariableInfo = this.schemerService.varList.find(
                   vi => vi.id === targetCoding.id
-                )) {
+                );
+                if (existingVariableInfo?.type === 'no-value') {
+                  existingVariableInfo.alias =
+                    targetCoding.alias || targetCoding.id;
+                  existingVariableInfo.type = 'string';
+                  existingVariableInfo.format = '';
+                  existingVariableInfo.multiple = true;
+                  existingVariableInfo.nullable = true;
+                  existingVariableInfo.values = [];
+                  existingVariableInfo.valuePositionLabels = [];
+                } else if (!existingVariableInfo) {
                   this.schemerService.varList.push({
                     id: targetCoding.id,
                     alias: targetCoding.alias || targetCoding.id,


### PR DESCRIPTION
## Summary
- convert existing `no-value` varList entries when activating `BASE_NO_VALUE` codings
- keep existing non-`no-value` varList entries unchanged to avoid losing type metadata
- add a regression test covering the `INVALID_SOURCE` case

## Root cause
Activating a `BASE_NO_VALUE` coding changed the coding source type to `BASE`, but skipped varList updates whenever an entry with the same id already existed. If that existing entry still had `type: no-value`, validation reported `INVALID_SOURCE`.

## Validation
- `npm run lint`
- `npm run test:cc`
