### PR TITLE
Add MathTable coding generation

### DIFF
--- a/projects/ngx-coding-components/src/lib/translations/de.json
+++ b/projects/ngx-coding-components/src/lib/translations/de.json
@@ -167,7 +167,15 @@
         "integer": "Ein Code wird erzeugt für numerische Regeln.",
         "simple-input": "Ein Code wird erzeugt für einen Textinput.",
         "simple-input-not-numeric": "Text input wird als Text interpretiert (ggf. auch mehrere Zeilen, eine Zeile pro Wert).",
-        "simple-input-numeric": "Soll der Textinput als Zahl interpretiert werden? (eine Zeile für einen Wert, neue Zeile für weiteren Wert):"
+        "simple-input-numeric": "Soll der Textinput als Zahl interpretiert werden? (eine Zeile für einen Wert, neue Zeile für weiteren Wert):",
+        "math-table": "Rechenkästchen: Es wird eine Kodierstruktur für das strukturierte Antwortformat erzeugt."
+      },
+      "math-table": {
+        "mode-prompt": "Welche Kodierstruktur soll erzeugt werden?",
+        "mode-result-auto": "Ergebniszeile automatisch prüfen",
+        "mode-manual": "Rechenweg manuell prüfen",
+        "expected-result": "Erwartetes Ergebnis",
+        "expected-result-hint": "Der Wert wird mit der Ergebniszeile des Rechenkästchens verglichen."
       },
       "else-method": {
         "prompt": "Methode für Abschluss",

--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/generate-coding-dialog.component.html
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/generate-coding-dialog.component.html
@@ -103,6 +103,54 @@
       }}</mat-checkbox>
       }
     </div>
+    } @if (generationModel === 'math-table') {
+    <div class="fx-column-start-stretch fx-gap-10">
+      <mat-label>{{
+        "coding.generate.math-table.mode-prompt" | translate
+      }}</mat-label>
+      <mat-radio-group [(ngModel)]="mathTableMode" class="fx-column-start-start">
+        <mat-radio-button [value]="'result-auto'">{{
+          "coding.generate.math-table.mode-result-auto" | translate
+        }}</mat-radio-button>
+        <mat-radio-button [value]="'manual'">{{
+          "coding.generate.math-table.mode-manual" | translate
+        }}</mat-radio-button>
+      </mat-radio-group>
+
+      @if (requiresMathTableExpectedResult()) {
+      <div class="fx-row-start-start fx-gap-10">
+        <mat-form-field>
+          <mat-label>{{
+            "coding.generate.math-table.expected-result" | translate
+          }}</mat-label>
+          <input
+            matInput
+            [(ngModel)]="mathTableExpectedResult"
+          />
+        </mat-form-field>
+        <div>
+          {{ "coding.generate.math-table.expected-result-hint" | translate }}
+        </div>
+      </div>
+
+      <div class="fx-column-start-stretch">
+        <mat-label>{{
+          "coding.generate.else-method.prompt" | translate
+        }}</mat-label>
+        <mat-radio-group [(ngModel)]="elseMethod" class="fx-gap-20">
+          <mat-radio-button [value]="'auto'">{{
+            "coding.generate.else-method.auto" | translate
+          }}</mat-radio-button>
+          <mat-radio-button [value]="'instruction'">{{
+            "coding.generate.else-method.instruction" | translate
+          }}</mat-radio-button>
+          <mat-radio-button [value]="'none'">{{
+            "coding.generate.else-method.none" | translate
+          }}</mat-radio-button>
+        </mat-radio-group>
+      </div>
+      }
+    </div>
     } @if (generationModel === 'single-choice-some') {
     <mat-selection-list [(ngModel)]="selectedOptions" multiple="false">
       @for (c of options; track c) {
@@ -268,7 +316,7 @@
   <button
     mat-raised-button
     color="primary"
-    [disabled]="generationModel === 'none'"
+    [disabled]="!canGenerate()"
     (click)="generateButtonClick()"
   >
     {{ "coding.generate.action" | translate }}

--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/generate-coding-dialog.component.spec.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/generate-coding-dialog.component.spec.ts
@@ -166,6 +166,98 @@ describe('GenerateCodingDialogComponent', () => {
     expect(dialogRef.close).toHaveBeenCalledWith(null);
   });
 
+  it('constructor should detect math-table variables and require an expected result for auto mode', () => {
+    const { component } = createComponent({
+      type: 'json',
+      format: 'math-table'
+    });
+
+    expect(component.generationModel).toBe('math-table');
+    expect(component.elseMethod).toBe('auto');
+    expect(component.canGenerate()).toBeFalse();
+
+    component.mathTableExpectedResult = '579';
+
+    expect(component.canGenerate()).toBeTrue();
+  });
+
+  it('generateButtonClick should not generate math-table result coding without expected result', () => {
+    const { component, dialogRef, schemerService } = createComponent({
+      type: 'json',
+      format: 'math-table'
+    });
+
+    component.generateButtonClick();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(null);
+    expect(schemerService.addCode).not.toHaveBeenCalled();
+  });
+
+  it('generateButtonClick should generate math-table result MATCH_REGEX and residual auto code', () => {
+    const { component, dialogRef, schemerService } = createComponent({
+      type: 'json',
+      format: 'math-table'
+    });
+
+    component.mathTableExpectedResult = '579';
+
+    schemerService.addCode.and.callFake((codes: CodeData[], type: CodeType) => {
+      const code = {
+        id: type === 'RESIDUAL_AUTO' ? 0 : codes.length + 1,
+        type
+      } as CodeData;
+      codes.push(code);
+      return code;
+    });
+
+    component.generateButtonClick();
+
+    const closed = (dialogRef.close as jasmine.Spy).calls.mostRecent().args[0] as unknown as
+      { codeModel: string; codes: CodeData[] };
+    const fullCredit = closed.codes.find(c => c.type === 'FULL_CREDIT')!;
+    const residualAuto = closed.codes.find(c => c.type === 'RESIDUAL_AUTO');
+
+    expect(closed.codeModel).toBe('RULES_ONLY');
+    expect(fullCredit.ruleSets?.[0].rules[0].method).toBe('MATCH_REGEX');
+    expect(fullCredit.ruleSets?.[0].rules[0].parameters?.[0]).toContain('"rowType"');
+    expect(residualAuto).toBeDefined();
+  });
+
+  it('generateButtonClick should generate manual math-table code structure without rules', () => {
+    const { component, dialogRef, schemerService } = createComponent({
+      type: 'json',
+      format: 'math-table'
+    });
+
+    component.mathTableMode = 'manual';
+
+    schemerService.addCode.and.callFake((codes: CodeData[], type: CodeType) => {
+      const code = {
+        id: codes.length + 1,
+        type,
+        ruleSets: [{ ruleOperatorAnd: false, rules: [] }]
+      } as CodeData;
+      codes.push(code);
+      return code;
+    });
+
+    component.generateButtonClick();
+
+    const closed = (dialogRef.close as jasmine.Spy).calls.mostRecent().args[0] as unknown as
+      { codeModel: string; manualInstruction: string; codes: CodeData[] };
+
+    expect(closed.codeModel).toBe('MANUAL_ONLY');
+    expect(closed.manualInstruction).toContain('Rechenweg');
+    const codeTypes: string[] = closed.codes.map(c => c.type || '').sort();
+    expect(codeTypes).toEqual([
+      'FULL_CREDIT',
+      'NO_CREDIT',
+      'PARTIAL_CREDIT',
+      'TO_CHECK'
+    ].sort());
+    expect(closed.codes.every(c => (c.ruleSets || []).length === 0)).toBeTrue();
+  });
+
   it('generateButtonClick should generate numeric MATCH rule for integer model and close var data', () => {
     const { component, dialogRef, schemerService } = createComponent({
       type: 'integer',

--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/generate-coding-dialog.component.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/generate-coding-dialog.component.ts
@@ -30,6 +30,7 @@ import { MatCheckbox } from '@angular/material/checkbox';
 import { MatLabel, MatFormField } from '@angular/material/form-field';
 import {
   CodeData,
+  CodeType,
   CodeModelType,
   CodingRule,
   ProcessingParameterType,
@@ -39,12 +40,21 @@ import {
 import { ToTextFactory } from '@iqb/responses';
 import { VariableInfo } from '@iqbspecs/variable-info/variable-info.interface';
 import { SchemerService } from '../../services/schemer.service';
+import {
+  createMathTableResultRule,
+  isMathTableVariableInfo,
+  MathTableGenerationMode,
+  MATH_TABLE_GENERAL_MANUAL_INSTRUCTION,
+  MATH_TABLE_MANUAL_CODE_INSTRUCTIONS,
+  normaliseMathTableExpectedResult
+} from './math-table-coding-generator';
 
 export interface GeneratedCodingData {
   id: string;
   alias: string;
   processing: ProcessingParameterType[];
   fragmenting: string;
+  manualInstruction?: string;
   codeModel: CodeModelType;
   codes: CodeData[];
 }
@@ -110,7 +120,8 @@ export class GenerateCodingDialogComponent {
   | 'multi-choice'
   | 'integer'
   | 'simple-input'
-  | 'boolean-multi';
+  | 'boolean-multi'
+  | 'math-table';
 
   protected readonly ToTextFactory = ToTextFactory;
   selectedOption: string = '';
@@ -132,6 +143,8 @@ export class GenerateCodingDialogComponent {
   numericRuleText = '';
   numericRuleError = false;
   elseMethod: 'none' | 'auto' | 'instruction' = 'none';
+  mathTableMode: MathTableGenerationMode = 'result-auto';
+  mathTableExpectedResult = '';
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public varInfo: VariableInfo,
@@ -141,6 +154,12 @@ export class GenerateCodingDialogComponent {
   ) {
     this.generationModel = 'none';
     if (!varInfo) {
+      return;
+    }
+
+    if (isMathTableVariableInfo(varInfo)) {
+      this.generationModel = 'math-table';
+      this.elseMethod = 'auto';
       return;
     }
 
@@ -349,8 +368,111 @@ export class GenerateCodingDialogComponent {
     }
   }
 
-  generateButtonClick() {
+  requiresMathTableExpectedResult(): boolean {
+    return this.generationModel === 'math-table' &&
+      this.mathTableMode === 'result-auto';
+  }
+
+  canGenerate(): boolean {
     if (this.generationModel === 'none') {
+      return false;
+    }
+
+    if (this.requiresMathTableExpectedResult()) {
+      return normaliseMathTableExpectedResult(this.mathTableExpectedResult).length > 0;
+    }
+
+    return true;
+  }
+
+  private addCodeToVariable(
+    newVardata: VariableCodingData,
+    codeType: CodeType
+  ): CodeData | null {
+    const newCode = this.schemerService.addCode(
+      newVardata.codes || [],
+      codeType
+    );
+
+    return typeof newCode === 'string' ? null : newCode;
+  }
+
+  private addMathTableResultAutoCode(newVardata: VariableCodingData): boolean {
+    const newCode = this.addCodeToVariable(newVardata, 'FULL_CREDIT');
+    if (!newCode) return false;
+
+    newCode.ruleSetOperatorAnd = true;
+    newCode.ruleSets = [
+      <RuleSet>{
+        ruleOperatorAnd: false,
+        rules: [
+          createMathTableResultRule(this.mathTableExpectedResult)
+        ]
+      }
+    ];
+    return true;
+  }
+
+  private addMathTableResidualCode(newVardata: VariableCodingData): boolean {
+    if (!['auto', 'instruction'].includes(this.elseMethod)) return true;
+
+    const newResidualCode = this.addCodeToVariable(
+      newVardata,
+      this.elseMethod === 'instruction' ? 'RESIDUAL' : 'RESIDUAL_AUTO'
+    );
+
+    return !!newResidualCode;
+  }
+
+  private addMathTableManualCodes(newVardata: VariableCodingData): boolean {
+    return ([
+      'FULL_CREDIT',
+      'PARTIAL_CREDIT',
+      'NO_CREDIT',
+      'TO_CHECK'
+    ] as CodeType[]).every(codeType => {
+      const newCode = this.addCodeToVariable(newVardata, codeType);
+      if (!newCode) return false;
+
+      newCode.ruleSetOperatorAnd = true;
+      newCode.ruleSets = [];
+      newCode.manualInstruction =
+        MATH_TABLE_MANUAL_CODE_INSTRUCTIONS[codeType] || '';
+
+      return true;
+    });
+  }
+
+  private generateMathTableCoding(newVardata: VariableCodingData): void {
+    if (this.mathTableMode === 'manual') {
+      newVardata.codeModel = 'MANUAL_ONLY';
+      newVardata.manualInstruction = MATH_TABLE_GENERAL_MANUAL_INSTRUCTION;
+
+      if (!this.addMathTableManualCodes(newVardata)) {
+        this.dialogRef.close(null);
+        return;
+      }
+
+      this.dialogRef.close(newVardata);
+      return;
+    }
+
+    newVardata.codeModel = 'RULES_ONLY';
+    newVardata.manualInstruction = '';
+
+    if (
+      !this.addMathTableResultAutoCode(newVardata) ||
+      !this.addMathTableResidualCode(newVardata)
+    ) {
+      this.dialogRef.close(null);
+      return;
+    }
+
+    this.dialogRef.close(newVardata);
+  }
+
+  generateButtonClick() {
+    if (!this.canGenerate()) {
       this.dialogRef.close(null);
     } else {
       const newVardata: VariableCodingData = {
@@ -369,6 +491,11 @@ export class GenerateCodingDialogComponent {
         codeModel: 'MANUAL_AND_RULES',
         codes: []
       };
+      if (this.generationModel === 'math-table') {
+        this.generateMathTableCoding(newVardata);
+        return;
+      }
+
       if (['auto', 'instruction'].includes(this.elseMethod)) {
         const newResidualCode = this.schemerService.addCode(
           newVardata.codes || [],

--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/math-table-coding-generator.spec.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/math-table-coding-generator.spec.ts
@@ -1,0 +1,83 @@
+import {
+  createMathTableResultRule,
+  createMathTableResultRulePattern,
+  isMathTableVariableInfo,
+  normaliseMathTableExpectedResult
+} from './math-table-coding-generator';
+
+describe('math-table-coding-generator', () => {
+  const createMathTableResponseValue = (resultValues: string[]): string => JSON.stringify([
+    {
+      rowType: 'normal',
+      cells: [
+        { value: '1', isEditable: false },
+        { value: '2', isEditable: false }
+      ]
+    },
+    {
+      rowType: 'result',
+      cells: resultValues.map(value => ({ value, isEditable: true }))
+    }
+  ]);
+
+  it('isMathTableVariableInfo should detect json math-table variables', () => {
+    expect(isMathTableVariableInfo({
+      id: 'v1',
+      alias: 'V1',
+      type: 'json',
+      format: 'math-table',
+      multiple: false,
+      nullable: false,
+      values: [],
+      valuePositionLabels: []
+    })).toBeTrue();
+
+    expect(isMathTableVariableInfo({
+      id: 'v1',
+      alias: 'V1',
+      type: 'string',
+      format: '',
+      multiple: false,
+      nullable: false,
+      values: [],
+      valuePositionLabels: []
+    })).toBeFalse();
+  });
+
+  it('normaliseMathTableExpectedResult should remove spaces and use math-table char replacements', () => {
+    expect(normaliseMathTableExpectedResult(' - 12 / 3 * 4 ')).toBe('\u221212:3\u20224');
+  });
+
+  it('createMathTableResultRulePattern should match the result row value', () => {
+    const pattern = createMathTableResultRulePattern('579');
+    const responseValue = createMathTableResponseValue(['', '', '5', '7', '9']);
+
+    expect(new RegExp(pattern).test(responseValue)).toBeTrue();
+  });
+
+  it('createMathTableResultRulePattern should rely on the current Aspect row property order', () => {
+    const pattern = createMathTableResultRulePattern('579');
+    const responseValue = JSON.stringify([
+      {
+        cells: ['5', '7', '9'].map(value => ({ value, isEditable: true })),
+        rowType: 'result'
+      }
+    ]);
+
+    expect(new RegExp(pattern).test(responseValue)).toBeFalse();
+  });
+
+  it('createMathTableResultRulePattern should not match a different result row value', () => {
+    const pattern = createMathTableResultRulePattern('579');
+    const responseValue = createMathTableResponseValue(['', '', '5', '7', '8']);
+
+    expect(new RegExp(pattern).test(responseValue)).toBeFalse();
+  });
+
+  it('createMathTableResultRule should create a MATCH_REGEX rule', () => {
+    const rule = createMathTableResultRule('579');
+
+    expect(rule.method).toBe('MATCH_REGEX');
+    expect(rule.parameters?.length).toBe(1);
+  });
+});

--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/math-table-coding-generator.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/math-table-coding-generator.ts
@@ -1,0 +1,68 @@
+import {
+  CodeType,
+  CodingRule
+} from '@iqbspecs/coding-scheme/coding-scheme.interface';
+import { VariableInfo } from '@iqbspecs/variable-info/variable-info.interface';
+
+export type MathTableGenerationMode = 'result-auto' | 'manual';
+
+export const MATH_TABLE_GENERAL_MANUAL_INSTRUCTION =
+  '<p>Bitte Ergebniszeile, Rechenweg, Hilfszeilen und ggf. Durchstreichungen pr&uuml;fen.</p>';
+
+export const MATH_TABLE_MANUAL_CODE_INSTRUCTIONS: Partial<Record<CodeType, string>> = {
+  FULL_CREDIT: '<p>Ergebnis und Rechenweg sind richtig.</p>',
+  PARTIAL_CREDIT: '<p>Antwort teilweise richtig, z. B. nachvollziehbarer Rechenweg mit Fehlern.</p>',
+  NO_CREDIT: '<p>Antwort falsch oder nicht nachvollziehbar.</p>',
+  TO_CHECK: '<p>Antwort muss manuell gepr&uuml;ft werden.</p>'
+};
+
+export const isMathTableVariableInfo = (varInfo: VariableInfo | null | undefined): boolean => (
+  varInfo?.type === 'json' && varInfo.format === 'math-table'
+);
+
+export const normaliseMathTableExpectedResult = (value: string): string => (
+  (value || '')
+    .replace(/\s+/g, '')
+    .replace(/-/g, '\u2212')
+    .replace(/\*/g, '\u2022')
+    .replace(/\//g, ':')
+);
+
+const escapeRegExp = (value: string): string => (
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+);
+
+const escapeJsonStringValueForRegExp = (value: string): string => (
+  escapeRegExp(JSON.stringify(value).slice(1, -1))
+);
+
+const createCellWithValuePattern = (valuePattern: string): string => (
+  `\\{[^{}]*"value"\\s*:\\s*"${valuePattern}"[^{}]*\\}`
+);
+
+export const createMathTableResultRulePattern = (expectedResult: string): string => {
+  const normalisedResult = normaliseMathTableExpectedResult(expectedResult);
+
+  if (!normalisedResult) {
+    return '(?!)';
+  }
+
+  const emptyCellPattern = createCellWithValuePattern('(?:|\\s)');
+  const expectedCellPatterns = normalisedResult
+    .split('')
+    .map(char => createCellWithValuePattern(escapeJsonStringValueForRegExp(char)))
+    .join('\\s*,\\s*');
+
+  return [
+    '"rowType"\\s*:\\s*"result"',
+    '\\s*,\\s*"cells"\\s*:\\s*\\[',
+    `\\s*(?:${emptyCellPattern}\\s*,\\s*)*`,
+    expectedCellPatterns,
+    `(?:\\s*,\\s*${emptyCellPattern})*\\s*\\]`
+  ].join('');
+};
+
+export const createMathTableResultRule = (expectedResult: string): CodingRule => ({
+  method: 'MATCH_REGEX',
+  parameters: [createMathTableResultRulePattern(expectedResult)]
+});

--- a/projects/ngx-coding-components/src/lib/var-coding/var-coding.component.spec.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/var-coding.component.spec.ts
@@ -496,6 +496,7 @@ describe('VarCodingComponent', () => {
       afterClosed: () => of({
         processing: ['SORT_ARRAY'],
         fragmenting: 'x',
+        manualInstruction: '<p>generated</p>',
         codeModel: 'SOME',
         codes: [{
           id: 0, type: 'RESIDUAL_AUTO', label: '', score: 0
@@ -506,6 +507,7 @@ describe('VarCodingComponent', () => {
     component.smartSchemer({ ctrlKey: false } as unknown as MouseEvent);
 
     expect(component.varCoding?.processing).toEqual(['SORT_ARRAY']);
+    expect(component.varCoding?.manualInstruction).toBe('<p>generated</p>');
     expect(component.hasResidualAutoCode).toBeTrue();
     expect(emitSpy).toHaveBeenCalledWith(component.varCoding);
   });

--- a/projects/ngx-coding-components/src/lib/var-coding/var-coding.component.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/var-coding.component.ts
@@ -316,6 +316,7 @@ export class VarCodingComponent implements OnInit, OnDestroy, OnChanges {
             Object.assign(this.varCoding, {
               processing: newCoding.processing,
               fragmenting: newCoding.fragmenting,
+              manualInstruction: newCoding.manualInstruction || '',
               codeModel: newCoding.codeModel,
               codes: newCoding.codes
             });


### PR DESCRIPTION
## Summary
- add MathTable smart-generation for `json` variables with `format: math-table`
- generate automatic result-row regex coding for the current Aspect JSON response string
- add a manual-only MathTable coding structure and carry generated variable instructions into Smart Schemer output
- cover the current Aspect row property order and the empty-result guard with tests

## Notes
- Related to #172; intentionally does not close it.
- Follow-up for a structured `@iqb/responses` extractor is tracked in #197.

## Checks
- `npx ng test ngx-coding-components --watch=false --browsers=ChromeHeadless --include=projects/ngx-coding-components/src/lib/var-coding/dialogs/generate-coding-dialog.component.spec.ts --include=projects/ngx-coding-components/src/lib/var-coding/dialogs/math-table-coding-generator.spec.ts --include=projects/ngx-coding-components/src/lib/var-coding/var-coding.component.spec.ts` (`47 SUCCESS`)
- `npm run lint -- --quiet`
