### PR TITLE
Schemer: support GeoGebra variable value coding

### DIFF
--- a/projects/ngx-coding-components/src/lib/translations/de.json
+++ b/projects/ngx-coding-components/src/lib/translations/de.json
@@ -175,9 +175,13 @@
         "extract-value": "GeoGebra-Wert hinter '=' kodieren",
         "mode-prompt": "Wie soll der GeoGebra-Wert kodiert werden?",
         "mode-numeric": "Zahl",
+        "mode-angle": "Winkel",
+        "mode-point": "Punkt",
         "mode-boolean": "Wahr/Falsch",
         "mode-text": "Text",
-        "boolean-prompt": "Welcher Wert ist richtig?"
+        "boolean-prompt": "Welcher Wert ist richtig?",
+        "point-x": "x-Koordinate",
+        "point-y": "y-Koordinate"
       },
       "math-table": {
         "mode-prompt": "Welche Kodierstruktur soll erzeugt werden?",

--- a/projects/ngx-coding-components/src/lib/translations/de.json
+++ b/projects/ngx-coding-components/src/lib/translations/de.json
@@ -168,7 +168,16 @@
         "simple-input": "Ein Code wird erzeugt für einen Textinput.",
         "simple-input-not-numeric": "Text input wird als Text interpretiert (ggf. auch mehrere Zeilen, eine Zeile pro Wert).",
         "simple-input-numeric": "Soll der Textinput als Zahl interpretiert werden? (eine Zeile für einen Wert, neue Zeile für weiteren Wert):",
+        "geogebra-boolean": "GeoGebra-Wert wird als Wahr/Falsch-Wert kodiert.",
         "math-table": "Rechenkästchen: Es wird eine Kodierstruktur für das strukturierte Antwortformat erzeugt."
+      },
+      "geogebra": {
+        "extract-value": "GeoGebra-Wert hinter '=' kodieren",
+        "mode-prompt": "Wie soll der GeoGebra-Wert kodiert werden?",
+        "mode-numeric": "Zahl",
+        "mode-boolean": "Wahr/Falsch",
+        "mode-text": "Text",
+        "boolean-prompt": "Welcher Wert ist richtig?"
       },
       "math-table": {
         "mode-prompt": "Welche Kodierstruktur soll erzeugt werden?",

--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/generate-coding-dialog.component.html
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/generate-coding-dialog.component.html
@@ -197,6 +197,37 @@
       </mat-select>
     </mat-form-field>
     }
+    @if (isGeoGebraVariable) {
+    <div class="fx-column-start-stretch fx-gap-10">
+      <div class="fx-row-start-center">
+        <mat-label>{{
+          "coding.generate.geogebra.extract-value" | translate
+        }}</mat-label>
+        <mat-checkbox
+          [(ngModel)]="geogebraExtractValue"
+          [style.margin.px]="8"
+        ></mat-checkbox>
+      </div>
+      <mat-label>{{
+        "coding.generate.geogebra.mode-prompt" | translate
+      }}</mat-label>
+      <mat-radio-group
+        [(ngModel)]="geogebraCodingMode"
+        (ngModelChange)="setGeoGebraCodingMode($event)"
+        class="fx-gap-20"
+      >
+        <mat-radio-button [value]="'numeric'">{{
+          "coding.generate.geogebra.mode-numeric" | translate
+        }}</mat-radio-button>
+        <mat-radio-button [value]="'boolean'">{{
+          "coding.generate.geogebra.mode-boolean" | translate
+        }}</mat-radio-button>
+        <mat-radio-button [value]="'text'">{{
+          "coding.generate.geogebra.mode-text" | translate
+        }}</mat-radio-button>
+      </mat-radio-group>
+    </div>
+    } @else {
     <div class="fx-row-start-center">
       <mat-label>{{
         "coding.generate.model.simple-input-numeric" | translate
@@ -206,8 +237,32 @@
         [style.margin.px]="8"
       ></mat-checkbox>
     </div>
-    } @if (generationModel === 'integer' || (textAsNumeric && generationModel
-    === 'simple-input')) {
+    }
+    } @if (isGeoGebraVariable && generationModel !== 'simple-input') {
+    <div class="fx-row-start-center">
+      <mat-label>{{
+        "coding.generate.geogebra.extract-value" | translate
+      }}</mat-label>
+      <mat-checkbox
+        [(ngModel)]="geogebraExtractValue"
+        [style.margin.px]="8"
+      ></mat-checkbox>
+    </div>
+    } @if (isGeoGebraBooleanMode()) {
+    <div class="fx-column-start-stretch">
+      <mat-label>{{
+        "coding.generate.geogebra.boolean-prompt" | translate
+      }}</mat-label>
+      <mat-radio-group [(ngModel)]="geogebraBooleanValue" class="fx-gap-20">
+        <mat-radio-button [value]="'true'">{{
+          "rule.IS_TRUE" | translate
+        }}</mat-radio-button>
+        <mat-radio-button [value]="'false'">{{
+          "rule.IS_FALSE" | translate
+        }}</mat-radio-button>
+      </mat-radio-group>
+    </div>
+    } @if (isNumericCodingMode()) {
     <div class="fx-column-start-start">
       <div class="fx-row-start-center">
         <div [style.width.px]="200">{{ "rule.NUMERIC_MATCH" | translate }}</div>
@@ -271,7 +326,7 @@
         </div>
       </div>
     </div>
-    } @if (generationModel === 'simple-input' && !textAsNumeric) {
+    } @if (isTextInputCodingMode()) {
     <div class="fx-row-start-start fx-gap-10">
       <mat-form-field>
         <textarea
@@ -286,8 +341,8 @@
         {{ "coding.generate.model.simple-input-not-numeric" | translate }}
       </div>
     </div>
-    } @if (generationModel === 'simple-input' || generationModel === 'integer')
-    {
+    } @if (generationModel === 'simple-input' || generationModel === 'integer'
+    || generationModel === 'geogebra-boolean') {
     <div class="fx-column-start-stretch">
       <mat-label>{{
         "coding.generate.else-method.prompt" | translate

--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/generate-coding-dialog.component.html
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/generate-coding-dialog.component.html
@@ -205,6 +205,7 @@
         }}</mat-label>
         <mat-checkbox
           [(ngModel)]="geogebraExtractValue"
+          [disabled]="isGeoGebraPointMode()"
           [style.margin.px]="8"
         ></mat-checkbox>
       </div>
@@ -218,6 +219,12 @@
       >
         <mat-radio-button [value]="'numeric'">{{
           "coding.generate.geogebra.mode-numeric" | translate
+        }}</mat-radio-button>
+        <mat-radio-button [value]="'angle'">{{
+          "coding.generate.geogebra.mode-angle" | translate
+        }}</mat-radio-button>
+        <mat-radio-button [value]="'point'">{{
+          "coding.generate.geogebra.mode-point" | translate
         }}</mat-radio-button>
         <mat-radio-button [value]="'boolean'">{{
           "coding.generate.geogebra.mode-boolean" | translate
@@ -261,6 +268,31 @@
           "rule.IS_FALSE" | translate
         }}</mat-radio-button>
       </mat-radio-group>
+    </div>
+    } @if (isGeoGebraPointMode()) {
+    <div class="fx-column-start-start">
+      <div class="fx-row-start-center">
+        <div [style.width.px]="200">
+          {{ "coding.generate.geogebra.point-x" | translate }}
+        </div>
+        <mat-form-field>
+          <mat-label>{{
+            "coding.generate.geogebra.point-x" | translate
+          }}</mat-label>
+          <input matInput [(ngModel)]="geogebraPointX" />
+        </mat-form-field>
+      </div>
+      <div class="fx-row-start-center">
+        <div [style.width.px]="200">
+          {{ "coding.generate.geogebra.point-y" | translate }}
+        </div>
+        <mat-form-field>
+          <mat-label>{{
+            "coding.generate.geogebra.point-y" | translate
+          }}</mat-label>
+          <input matInput [(ngModel)]="geogebraPointY" />
+        </mat-form-field>
+      </div>
     </div>
     } @if (isNumericCodingMode()) {
     <div class="fx-column-start-start">

--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/generate-coding-dialog.component.spec.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/generate-coding-dialog.component.spec.ts
@@ -1,4 +1,5 @@
 import { CodingFactory } from '@iqb/responses/coding-factory';
+import { transformValue } from '@iqb/responses/value-transform';
 import { VariableInfo } from '@iqbspecs/variable-info/variable-info.interface';
 import { TranslateService } from '@ngx-translate/core';
 import { MatDialogRef } from '@angular/material/dialog';
@@ -365,7 +366,9 @@ describe('GenerateCodingDialogComponent', () => {
     const closed = (dialogRef.close as jasmine.Spy).calls.mostRecent().args[0] as VariableCodingData;
     const fullCredit = (closed.codes || []).find(c => c.type === 'FULL_CREDIT') as CodeData;
 
-    expect(closed.fragmenting).toBe('^\\s*ggb_490000\\s*=\\s*(.*?)\\s*$');
+    expect(closed.fragmenting).toBe(
+      '^\\s*ggb_490000\\s*=\\s*([-+]?\\d+(?:[.,]\\d+)?)\\s*$'
+    );
     expect(fullCredit.ruleSets?.[0].rules[0]).toEqual({
       method: 'NUMERIC_MATCH',
       parameters: ['429979.167']
@@ -380,6 +383,151 @@ describe('GenerateCodingDialogComponent', () => {
       closed
     );
 
+    expect(coded.code).toBe(1);
+    expect(coded.score).toBe(1);
+  });
+
+  it('generateButtonClick should fragment GeoGebra angle values without the degree symbol', () => {
+    const { component, dialogRef, schemerService } = createComponent({
+      id: 'α',
+      alias: 'Winkel',
+      type: 'string',
+      format: 'ggb-variable'
+    });
+
+    component.setGeoGebraCodingMode('angle');
+    component.numericMatch = '-42.14159';
+
+    schemerService.addCode.and.callFake((codes: CodeData[], type: CodeType) => {
+      const code = {
+        id: type === 'RESIDUAL_AUTO' ? 0 : 1,
+        type,
+        score: type === 'FULL_CREDIT' ? 1 : 0
+      } as CodeData;
+      codes.push(code);
+      return code;
+    });
+
+    component.generateButtonClick();
+
+    const closed = (dialogRef.close as jasmine.Spy).calls.mostRecent().args[0] as VariableCodingData;
+
+    expect(closed.fragmenting).toBe(
+      '^\\s*α\\s*=\\s*([-+]?\\d+(?:[.,]\\d+)?)\\s*°?\\s*$'
+    );
+    expect(transformValue('α = -42.14159°', closed.fragmenting || '', false)).toEqual(['-42.14159']);
+  });
+
+  it('generateButtonClick should generate GeoGebra point rules for both coordinates', () => {
+    const { component, dialogRef, schemerService } = createComponent({
+      id: 'A',
+      alias: 'Punkt A',
+      type: 'string',
+      format: 'ggb-variable'
+    });
+
+    component.setGeoGebraCodingMode('point');
+    component.geogebraPointX = '-1.3';
+    component.geogebraPointY = '2.4';
+
+    schemerService.addCode.and.callFake((codes: CodeData[], type: CodeType) => {
+      const code = {
+        id: type === 'RESIDUAL_AUTO' ? 0 : 1,
+        type,
+        score: type === 'FULL_CREDIT' ? 1 : 0
+      } as CodeData;
+      codes.push(code);
+      return code;
+    });
+
+    component.generateButtonClick();
+
+    const closed = (dialogRef.close as jasmine.Spy).calls.mostRecent().args[0] as VariableCodingData;
+    const fullCredit = (closed.codes || []).find(c => c.type === 'FULL_CREDIT') as CodeData;
+
+    expect(closed.fragmenting).toBe(
+      '^\\s*A\\s*=\\s*\\(\\s*([-+]?\\d+(?:[.,]\\d+)?)\\s*,\\s*([-+]?\\d+(?:[.,]\\d+)?)\\s*\\)\\s*$'
+    );
+    expect(transformValue('A = (-1.3, 2.4)', closed.fragmenting || '', false)).toEqual(['-1.3', '2.4']);
+    expect(fullCredit.ruleSets?.[0]).toEqual({
+      ruleOperatorAnd: true,
+      rules: [
+        {
+          method: 'NUMERIC_MATCH',
+          parameters: ['-1.3'],
+          fragment: 0
+        },
+        {
+          method: 'NUMERIC_MATCH',
+          parameters: ['2.4'],
+          fragment: 1
+        }
+      ]
+    });
+
+    const correct = CodingFactory.code(
+      {
+        id: 'A',
+        value: 'A = (-1.3, 2.4)',
+        status: 'VALUE_CHANGED'
+      },
+      closed
+    );
+    const wrongY = CodingFactory.code(
+      {
+        id: 'A',
+        value: 'A = (-1.3, 999)',
+        status: 'VALUE_CHANGED'
+      },
+      closed
+    );
+
+    expect(correct.code).toBe(1);
+    expect(correct.score).toBe(1);
+    expect(wrongY.code).not.toBe(1);
+    expect(wrongY.score).toBe(0);
+  });
+
+  it('generateButtonClick should force GeoGebra fragmenting for point rules', () => {
+    const { component, dialogRef, schemerService } = createComponent({
+      id: 'A',
+      alias: 'Punkt A',
+      type: 'string',
+      format: 'ggb-variable'
+    });
+
+    component.geogebraExtractValue = false;
+    component.setGeoGebraCodingMode('point');
+    expect(component.geogebraExtractValue).toBeTrue();
+    component.geogebraExtractValue = false;
+    component.geogebraPointX = '-1.3';
+    component.geogebraPointY = '2.4';
+
+    schemerService.addCode.and.callFake((codes: CodeData[], type: CodeType) => {
+      const code = {
+        id: type === 'RESIDUAL_AUTO' ? 0 : 1,
+        type,
+        score: type === 'FULL_CREDIT' ? 1 : 0
+      } as CodeData;
+      codes.push(code);
+      return code;
+    });
+
+    component.generateButtonClick();
+
+    const closed = (dialogRef.close as jasmine.Spy).calls.mostRecent().args[0] as VariableCodingData;
+    const coded = CodingFactory.code(
+      {
+        id: 'A',
+        value: 'A = (-1.3, 2.4)',
+        status: 'VALUE_CHANGED'
+      },
+      closed
+    );
+
+    expect(closed.fragmenting).toBe(
+      '^\\s*A\\s*=\\s*\\(\\s*([-+]?\\d+(?:[.,]\\d+)?)\\s*,\\s*([-+]?\\d+(?:[.,]\\d+)?)\\s*\\)\\s*$'
+    );
     expect(coded.code).toBe(1);
     expect(coded.score).toBe(1);
   });
@@ -412,7 +560,7 @@ describe('GenerateCodingDialogComponent', () => {
     const closed = (dialogRef.close as jasmine.Spy).calls.mostRecent().args[0] as VariableCodingData;
     const fullCredit = (closed.codes || []).find(c => c.type === 'FULL_CREDIT') as CodeData;
 
-    expect(closed.fragmenting).toBe('^\\s*ggb_PunktRichtig\\s*=\\s*(.*?)\\s*$');
+    expect(closed.fragmenting).toBe('^\\s*ggb_PunktRichtig\\s*=\\s*(true|false)\\s*$');
     expect(fullCredit.ruleSets?.[0].rules[0]).toEqual({
       method: 'IS_TRUE',
       parameters: []

--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/generate-coding-dialog.component.spec.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/generate-coding-dialog.component.spec.ts
@@ -2,7 +2,11 @@ import { CodingFactory } from '@iqb/responses/coding-factory';
 import { VariableInfo } from '@iqbspecs/variable-info/variable-info.interface';
 import { TranslateService } from '@ngx-translate/core';
 import { MatDialogRef } from '@angular/material/dialog';
-import { CodeData, CodeType } from '@iqbspecs/coding-scheme/coding-scheme.interface';
+import {
+  CodeData,
+  CodeType,
+  VariableCodingData
+} from '@iqbspecs/coding-scheme/coding-scheme.interface';
 import { SchemerService } from '../../services/schemer.service';
 import { GenerateCodingDialogComponent } from './generate-coding-dialog.component';
 
@@ -322,6 +326,7 @@ describe('GenerateCodingDialogComponent', () => {
     component.generateButtonClick();
 
     const closed = (dialogRef.close as jasmine.Spy).calls.mostRecent().args[0] as unknown as { codes: unknown[] };
+    expect((closed as { fragmenting?: string }).fragmenting).toBe('');
     const fullCredit = (closed.codes as Array<{ type: string; ruleSets:
     Array<{ rules: Array<{ method: string; parameters: string[] }> }> }>)
       .find(c => c.type === 'FULL_CREDIT')!;
@@ -329,6 +334,101 @@ describe('GenerateCodingDialogComponent', () => {
       method: 'MATCH',
       parameters: ['abc']
     });
+  });
+
+  it('generateButtonClick should fragment GeoGebra numeric values before numeric rules', () => {
+    const { component, dialogRef, schemerService } = createComponent({
+      id: 'ggb_490000',
+      alias: 'GGB',
+      type: 'string',
+      format: 'ggb-variable'
+    });
+
+    expect(component.generationModel).toBe('simple-input');
+    expect(component.textAsNumeric).toBeTrue();
+    expect(component.geogebraExtractValue).toBeTrue();
+
+    component.numericMatch = '429979.167';
+
+    schemerService.addCode.and.callFake((codes: CodeData[], type: CodeType) => {
+      const code = {
+        id: type === 'RESIDUAL_AUTO' ? 0 : 1,
+        type,
+        score: type === 'FULL_CREDIT' ? 1 : 0
+      } as CodeData;
+      codes.push(code);
+      return code;
+    });
+
+    component.generateButtonClick();
+
+    const closed = (dialogRef.close as jasmine.Spy).calls.mostRecent().args[0] as VariableCodingData;
+    const fullCredit = (closed.codes || []).find(c => c.type === 'FULL_CREDIT') as CodeData;
+
+    expect(closed.fragmenting).toBe('^\\s*ggb_490000\\s*=\\s*(.*?)\\s*$');
+    expect(fullCredit.ruleSets?.[0].rules[0]).toEqual({
+      method: 'NUMERIC_MATCH',
+      parameters: ['429979.167']
+    });
+
+    const coded = CodingFactory.code(
+      {
+        id: 'ggb_490000',
+        value: 'ggb_490000 = 429979.167',
+        status: 'VALUE_CHANGED'
+      },
+      closed
+    );
+
+    expect(coded.code).toBe(1);
+    expect(coded.score).toBe(1);
+  });
+
+  it('generateButtonClick should generate GeoGebra boolean rules for extracted true values', () => {
+    const { component, dialogRef, schemerService } = createComponent({
+      id: 'ggb_PunktRichtig',
+      alias: 'GGB Boolean',
+      type: 'boolean',
+      format: 'ggb-variable'
+    });
+
+    expect(component.generationModel).toBe('geogebra-boolean');
+    expect(component.geogebraExtractValue).toBeTrue();
+
+    component.geogebraBooleanValue = 'true';
+
+    schemerService.addCode.and.callFake((codes: CodeData[], type: CodeType) => {
+      const code = {
+        id: type === 'RESIDUAL_AUTO' ? 0 : 1,
+        type,
+        score: type === 'FULL_CREDIT' ? 1 : 0
+      } as CodeData;
+      codes.push(code);
+      return code;
+    });
+
+    component.generateButtonClick();
+
+    const closed = (dialogRef.close as jasmine.Spy).calls.mostRecent().args[0] as VariableCodingData;
+    const fullCredit = (closed.codes || []).find(c => c.type === 'FULL_CREDIT') as CodeData;
+
+    expect(closed.fragmenting).toBe('^\\s*ggb_PunktRichtig\\s*=\\s*(.*?)\\s*$');
+    expect(fullCredit.ruleSets?.[0].rules[0]).toEqual({
+      method: 'IS_TRUE',
+      parameters: []
+    });
+
+    const coded = CodingFactory.code(
+      {
+        id: 'ggb_PunktRichtig',
+        value: 'ggb_PunktRichtig = true',
+        status: 'VALUE_CHANGED'
+      },
+      closed
+    );
+
+    expect(coded.code).toBe(1);
+    expect(coded.score).toBe(1);
   });
 
   it('generateButtonClick should create multi-choice order-dependent ruleSets and close', () => {

--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/generate-coding-dialog.component.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/generate-coding-dialog.component.ts
@@ -48,6 +48,10 @@ import {
   MATH_TABLE_MANUAL_CODE_INSTRUCTIONS,
   normaliseMathTableExpectedResult
 } from './math-table-coding-generator';
+import {
+  createGeoGebraValueFragmenting,
+  isGeoGebraVariableInfo
+} from './geogebra-variable-coding-generator';
 
 export interface GeneratedCodingData {
   id: string;
@@ -121,6 +125,7 @@ export class GenerateCodingDialogComponent {
   | 'integer'
   | 'simple-input'
   | 'boolean-multi'
+  | 'geogebra-boolean'
   | 'math-table';
 
   protected readonly ToTextFactory = ToTextFactory;
@@ -145,6 +150,10 @@ export class GenerateCodingDialogComponent {
   elseMethod: 'none' | 'auto' | 'instruction' = 'none';
   mathTableMode: MathTableGenerationMode = 'result-auto';
   mathTableExpectedResult = '';
+  isGeoGebraVariable = false;
+  geogebraExtractValue = false;
+  geogebraCodingMode: 'numeric' | 'boolean' | 'text' = 'numeric';
+  geogebraBooleanValue: 'true' | 'false' = 'true';
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public varInfo: VariableInfo,
@@ -162,6 +171,9 @@ export class GenerateCodingDialogComponent {
       this.elseMethod = 'auto';
       return;
     }
+
+    this.isGeoGebraVariable = isGeoGebraVariableInfo(varInfo);
+    this.geogebraExtractValue = this.isGeoGebraVariable;
 
     if (varInfo.values?.length > 0) {
       this.elseMethod = varInfo.valuesComplete ? 'auto' : 'instruction';
@@ -209,8 +221,21 @@ export class GenerateCodingDialogComponent {
         case 'integer':
           this.generationModel = 'integer';
           break;
+        case 'number':
+          if (this.isGeoGebraVariable) {
+            this.generationModel = 'integer';
+          }
+          break;
         case 'string':
+          if (this.isGeoGebraVariable) {
+            this.textAsNumeric = true;
+          }
           this.generationModel = 'simple-input';
+          break;
+        case 'boolean':
+          if (this.isGeoGebraVariable) {
+            this.generationModel = 'geogebra-boolean';
+          }
           break;
         default:
           break;
@@ -218,6 +243,34 @@ export class GenerateCodingDialogComponent {
     }
 
     this.updateNumericRuleText();
+  }
+
+  setGeoGebraCodingMode(mode: 'numeric' | 'boolean' | 'text'): void {
+    this.geogebraCodingMode = mode;
+    this.textAsNumeric = mode === 'numeric';
+    if (this.textAsNumeric) {
+      this.updateNumericRuleText();
+    }
+  }
+
+  isGeoGebraBooleanMode(): boolean {
+    return this.generationModel === 'geogebra-boolean' ||
+      (this.isGeoGebraVariable &&
+        this.generationModel === 'simple-input' &&
+        this.geogebraCodingMode === 'boolean');
+  }
+
+  isNumericCodingMode(): boolean {
+    return this.generationModel === 'integer' ||
+      (this.generationModel === 'simple-input' &&
+        this.textAsNumeric &&
+        !this.isGeoGebraBooleanMode());
+  }
+
+  isTextInputCodingMode(): boolean {
+    return this.generationModel === 'simple-input' &&
+      !this.textAsNumeric &&
+      !this.isGeoGebraBooleanMode();
   }
 
   resetOptions(): void {
@@ -491,6 +544,9 @@ export class GenerateCodingDialogComponent {
         codeModel: 'MANUAL_AND_RULES',
         codes: []
       };
+      if (this.isGeoGebraVariable && this.geogebraExtractValue) {
+        newVardata.fragmenting = createGeoGebraValueFragmenting(this.varInfo);
+      }
       if (this.generationModel === 'math-table') {
         this.generateMathTableCoding(newVardata);
         return;
@@ -509,10 +565,29 @@ export class GenerateCodingDialogComponent {
           newResidualCode.id = 'INVALID';
         }
       }
-      if (
-        this.generationModel === 'integer' ||
-        (this.textAsNumeric && this.generationModel === 'simple-input')
-      ) {
+      if (this.isGeoGebraBooleanMode()) {
+        const newCode = this.schemerService.addCode(
+          newVardata.codes || [],
+          'FULL_CREDIT'
+        );
+        if (typeof newCode !== 'string') {
+          newCode.ruleSetOperatorAnd = true;
+          newCode.ruleSets = [
+            <RuleSet>{
+              ruleOperatorAnd: false,
+              rules: [
+                {
+                  method: this.geogebraBooleanValue === 'true' ? 'IS_TRUE' : 'IS_FALSE',
+                  parameters: []
+                }
+              ]
+            }
+          ];
+          this.dialogRef.close(newVardata);
+        } else {
+          this.dialogRef.close(null);
+        }
+      } else if (this.isNumericCodingMode()) {
         const numericRules: CodingRule[] = [];
         const matchValue = CodingFactory.getValueAsNumber(this.numericMatch);
         if (matchValue !== null && this.numericMatch !== '') {

--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/generate-coding-dialog.component.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/generate-coding-dialog.component.ts
@@ -50,6 +50,7 @@ import {
 } from './math-table-coding-generator';
 import {
   createGeoGebraValueFragmenting,
+  GeoGebraCodingMode,
   isGeoGebraVariableInfo
 } from './geogebra-variable-coding-generator';
 
@@ -152,7 +153,9 @@ export class GenerateCodingDialogComponent {
   mathTableExpectedResult = '';
   isGeoGebraVariable = false;
   geogebraExtractValue = false;
-  geogebraCodingMode: 'numeric' | 'boolean' | 'text' = 'numeric';
+  geogebraCodingMode: GeoGebraCodingMode = 'numeric';
+  geogebraPointX = '';
+  geogebraPointY = '';
   geogebraBooleanValue: 'true' | 'false' = 'true';
 
   constructor(
@@ -245,9 +248,12 @@ export class GenerateCodingDialogComponent {
     this.updateNumericRuleText();
   }
 
-  setGeoGebraCodingMode(mode: 'numeric' | 'boolean' | 'text'): void {
+  setGeoGebraCodingMode(mode: GeoGebraCodingMode): void {
     this.geogebraCodingMode = mode;
-    this.textAsNumeric = mode === 'numeric';
+    this.textAsNumeric = ['numeric', 'angle', 'point'].includes(mode);
+    if (mode === 'point') {
+      this.geogebraExtractValue = true;
+    }
     if (this.textAsNumeric) {
       this.updateNumericRuleText();
     }
@@ -260,11 +266,18 @@ export class GenerateCodingDialogComponent {
         this.geogebraCodingMode === 'boolean');
   }
 
+  isGeoGebraPointMode(): boolean {
+    return this.isGeoGebraVariable &&
+      this.generationModel === 'simple-input' &&
+      this.geogebraCodingMode === 'point';
+  }
+
   isNumericCodingMode(): boolean {
     return this.generationModel === 'integer' ||
       (this.generationModel === 'simple-input' &&
         this.textAsNumeric &&
-        !this.isGeoGebraBooleanMode());
+        !this.isGeoGebraBooleanMode() &&
+        !this.isGeoGebraPointMode());
   }
 
   isTextInputCodingMode(): boolean {
@@ -435,6 +448,10 @@ export class GenerateCodingDialogComponent {
       return normaliseMathTableExpectedResult(this.mathTableExpectedResult).length > 0;
     }
 
+    if (this.isGeoGebraPointMode()) {
+      return this.createGeoGebraPointRules() !== null;
+    }
+
     return true;
   }
 
@@ -496,6 +513,33 @@ export class GenerateCodingDialogComponent {
     });
   }
 
+  private createGeoGebraPointRules(): CodingRule[] | null {
+    const xValue = CodingFactory.getValueAsNumber(this.geogebraPointX);
+    const yValue = CodingFactory.getValueAsNumber(this.geogebraPointY);
+
+    if (
+      xValue === null ||
+      yValue === null ||
+      this.geogebraPointX === '' ||
+      this.geogebraPointY === ''
+    ) {
+      return null;
+    }
+
+    return [
+      {
+        method: 'NUMERIC_MATCH',
+        parameters: [xValue.toString(10)],
+        fragment: 0
+      },
+      {
+        method: 'NUMERIC_MATCH',
+        parameters: [yValue.toString(10)],
+        fragment: 1
+      }
+    ];
+  }
+
   private generateMathTableCoding(newVardata: VariableCodingData): void {
     if (this.mathTableMode === 'manual') {
       newVardata.codeModel = 'MANUAL_ONLY';
@@ -544,8 +588,13 @@ export class GenerateCodingDialogComponent {
         codeModel: 'MANUAL_AND_RULES',
         codes: []
       };
-      if (this.isGeoGebraVariable && this.geogebraExtractValue) {
-        newVardata.fragmenting = createGeoGebraValueFragmenting(this.varInfo);
+      if (this.isGeoGebraVariable && (this.geogebraExtractValue || this.isGeoGebraPointMode())) {
+        newVardata.fragmenting = createGeoGebraValueFragmenting(
+          this.varInfo,
+          this.generationModel === 'geogebra-boolean' ?
+            'boolean' :
+            this.geogebraCodingMode
+        );
       }
       if (this.generationModel === 'math-table') {
         this.generateMathTableCoding(newVardata);
@@ -565,7 +614,25 @@ export class GenerateCodingDialogComponent {
           newResidualCode.id = 'INVALID';
         }
       }
-      if (this.isGeoGebraBooleanMode()) {
+      if (this.isGeoGebraPointMode()) {
+        const pointRules = this.createGeoGebraPointRules();
+        const newCode = this.schemerService.addCode(
+          newVardata.codes || [],
+          'FULL_CREDIT'
+        );
+        if (typeof newCode !== 'string' && pointRules) {
+          newCode.ruleSetOperatorAnd = true;
+          newCode.ruleSets = [
+            <RuleSet>{
+              ruleOperatorAnd: true,
+              rules: pointRules
+            }
+          ];
+          this.dialogRef.close(newVardata);
+        } else {
+          this.dialogRef.close(null);
+        }
+      } else if (this.isGeoGebraBooleanMode()) {
         const newCode = this.schemerService.addCode(
           newVardata.codes || [],
           'FULL_CREDIT'

--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/geogebra-variable-coding-generator.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/geogebra-variable-coding-generator.ts
@@ -1,0 +1,12 @@
+import { VariableInfo } from '@iqbspecs/variable-info/variable-info.interface';
+
+export const isGeoGebraVariableInfo = (
+  varInfo: VariableInfo | null | undefined
+): boolean => varInfo?.format === 'ggb-variable';
+
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+export const createGeoGebraValueFragmenting = (varInfo: VariableInfo): string => {
+  const variablePattern = varInfo.id ? escapeRegExp(varInfo.id) : '[^=]+';
+  return `^\\s*${variablePattern}\\s*=\\s*(.*?)\\s*$`;
+};

--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/geogebra-variable-coding-generator.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/geogebra-variable-coding-generator.ts
@@ -1,12 +1,25 @@
 import { VariableInfo } from '@iqbspecs/variable-info/variable-info.interface';
 
+export type GeoGebraCodingMode = 'numeric' | 'angle' | 'point' | 'boolean' | 'text';
+
 export const isGeoGebraVariableInfo = (
   varInfo: VariableInfo | null | undefined
 ): boolean => varInfo?.format === 'ggb-variable';
 
 const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const geoGebraNumberPattern = '([-+]?\\d+(?:[.,]\\d+)?)';
 
-export const createGeoGebraValueFragmenting = (varInfo: VariableInfo): string => {
+export const createGeoGebraValueFragmenting = (
+  varInfo: VariableInfo,
+  mode: GeoGebraCodingMode = 'text'
+): string => {
   const variablePattern = varInfo.id ? escapeRegExp(varInfo.id) : '[^=]+';
-  return `^\\s*${variablePattern}\\s*=\\s*(.*?)\\s*$`;
+  const valuePatternByMode: Record<GeoGebraCodingMode, string> = {
+    numeric: geoGebraNumberPattern,
+    angle: `${geoGebraNumberPattern}\\s*°?`,
+    point: `\\(\\s*${geoGebraNumberPattern}\\s*,\\s*${geoGebraNumberPattern}\\s*\\)`,
+    boolean: '(true|false)',
+    text: '(.*?)'
+  };
+  return `^\\s*${variablePattern}\\s*=\\s*${valuePatternByMode[mode]}\\s*$`;
 };


### PR DESCRIPTION
## Summary

- detect Schemer variables with `format: "ggb-variable"` in the coding generation dialog
- offer extraction of the value behind `=` via generated fragmenting
- generate numeric and boolean rules against the extracted GeoGebra value
- keep normal string and integer generation behavior unchanged

## Context

Related to #178. This intentionally does not close the issue.

## Validation

- `npx eslint -c .eslintrc.cjs projects/ngx-coding-components/src/lib/var-coding/dialogs/generate-coding-dialog.component.ts projects/ngx-coding-components/src/lib/var-coding/dialogs/generate-coding-dialog.component.spec.ts projects/ngx-coding-components/src/lib/var-coding/dialogs/geogebra-variable-coding-generator.ts --ext .ts --no-cache`
- `npx ng test ngx-coding-components --watch=false --browsers=ChromeHeadless --include='projects/ngx-coding-components/src/lib/var-coding/dialogs/generate-coding-dialog.component.spec.ts'`
- `npm run test:cc`