### PR TITLE
Update @iqb/responses to 5.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/platform-browser-dynamic": "^20.3.25",
         "@angular/router": "^20.3.25",
         "@iqb/mathlive": "^0.4.1",
-        "@iqb/responses": "^5.1.0",
+        "@iqb/responses": "^5.2.0",
         "@iqbspecs/coding-scheme": "^3.4.1",
         "@iqbspecs/response": "^2.0.0",
         "@iqbspecs/validate-json": "^0.4.0",
@@ -3645,9 +3645,9 @@
       }
     },
     "node_modules/@iqb/responses": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@iqb/responses/-/responses-5.1.0.tgz",
-      "integrity": "sha512-1UOAe9msAMvtqh1aYgm2PCXhxbWbfk98OmyKrLAWLM/A3gLR+m09Q89QyH96MspbmWvi4BtQ95U2EYhqtevsiw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@iqb/responses/-/responses-5.2.0.tgz",
+      "integrity": "sha512-Pk1s0CFA/SeAdns/RdHEKMSt/WhHYRzM7jkU7p5n/Nt+1Hpwj4zkvS8uXfofNplYhV7lkeMes1kcceqqQ2fekw==",
       "license": "CC0 1.0",
       "dependencies": {
         "mathjs": "^12.4.2"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@angular/platform-browser-dynamic": "^20.3.25",
     "@angular/router": "^20.3.25",
     "@iqb/mathlive": "^0.4.1",
-    "@iqb/responses": "^5.1.0",
+    "@iqb/responses": "^5.2.0",
     "@iqbspecs/coding-scheme": "^3.4.1",
     "@iqbspecs/response": "^2.0.0",
     "@iqbspecs/validate-json": "^0.4.0",

--- a/projects/ngx-coding-components/package.json
+++ b/projects/ngx-coding-components/package.json
@@ -29,7 +29,7 @@
     "@angular/platform-browser": "^20.0.5",
     "@angular/platform-browser-dynamic": "^20.0.5",
     "@angular/router": "^20.0.5",
-    "@iqb/responses": "^5.1.0",
+    "@iqb/responses": "^5.2.0",
     "@iqbspecs/coding-scheme": "^3.4.1",
     "@iqbspecs/response": "^2.0.0",
     "@iqbspecs/variable-info": "^1.3.0",

--- a/projects/ngx-coding-components/src/lib/scheme-checker/scheme-checker.component.spec.ts
+++ b/projects/ngx-coding-components/src/lib/scheme-checker/scheme-checker.component.spec.ts
@@ -196,4 +196,45 @@ describe('SchemeCheckerComponent', () => {
 
     expect(byId('d1')).toBeUndefined();
   });
+
+  it('startEvaluation should code derived aliases that shadow their base source id', () => {
+    const code = {
+      id: 1,
+      type: 'FULL_CREDIT',
+      label: 'x',
+      score: 1,
+      ruleSets: []
+    };
+    const variableCodings: VariableCodingData[] = [
+      {
+        id: 'BASE_ID',
+        alias: 'INPUT',
+        sourceType: 'BASE',
+        codes: [code]
+      } as unknown as VariableCodingData,
+      {
+        id: 'DERIVED_ID',
+        alias: 'BASE_ID',
+        sourceType: 'COPY_VALUE',
+        deriveSources: ['BASE_ID'],
+        codes: [code]
+      } as unknown as VariableCodingData
+    ];
+
+    component.codingScheme = {
+      variableCodings
+    } as unknown as never;
+    component.values['INPUT'] = 'abc';
+
+    component.startEvaluation();
+
+    expect(dialogOpenSpy).toHaveBeenCalled();
+    const config = dialogOpenSpy.calls.mostRecent().args[1] as { data: { responses: Response[] } };
+    expect(config.data.responses.length).toBe(1);
+    expect(config.data.responses[0]).toEqual(jasmine.objectContaining({
+      id: 'BASE_ID',
+      value: 'abc',
+      status: 'CODING_INCOMPLETE'
+    }));
+  });
 });

--- a/projects/ngx-coding-components/src/lib/schemer/schemer.component.spec.ts
+++ b/projects/ngx-coding-components/src/lib/schemer/schemer.component.spec.ts
@@ -298,6 +298,120 @@ describe('SchemerComponent', () => {
     expect(b.alias).toBe('b');
   });
 
+  it('updateVariableLists should allow a derived variable to shadow its base source id as alias', () => {
+    const code = {
+      id: 1,
+      type: 'FULL_CREDIT',
+      label: 'x',
+      score: 1,
+      ruleSets: []
+    };
+
+    schemerService.setVarList([
+      {
+        id: 'BASE_ID',
+        alias: 'INPUT',
+        type: 'string',
+        format: '',
+        multiple: false,
+        nullable: false,
+        values: [],
+        valuePositionLabels: []
+      } as unknown as VariableInfo
+    ]);
+    schemerService.setCodingScheme({
+      variableCodings: [
+        {
+          id: 'BASE_ID',
+          alias: 'INPUT',
+          sourceType: 'BASE',
+          codes: [code]
+        } as unknown as VariableCodingData,
+        {
+          id: 'DERIVED_ID',
+          alias: 'BASE_ID',
+          sourceType: 'COPY_VALUE',
+          deriveSources: ['BASE_ID'],
+          codes: [code]
+        } as unknown as VariableCodingData
+      ]
+    } as unknown as never);
+
+    component.updateVariableLists();
+
+    expect(component.problems).toEqual([]);
+    expect(component.codingStatus['BASE_ID']).toBe('OK');
+    expect(component.codingStatus['DERIVED_ID']).toBe('OK');
+  });
+
+  it('updateVariableLists should keep reporting real alias/id collisions', () => {
+    const code = {
+      id: 1,
+      type: 'FULL_CREDIT',
+      label: 'x',
+      score: 1,
+      ruleSets: []
+    };
+
+    schemerService.setVarList([
+      {
+        id: 'BASE_ID',
+        alias: 'INPUT',
+        type: 'string',
+        format: '',
+        multiple: false,
+        nullable: false,
+        values: [],
+        valuePositionLabels: []
+      } as unknown as VariableInfo,
+      {
+        id: 'OTHER_ID',
+        alias: 'OTHER',
+        type: 'string',
+        format: '',
+        multiple: false,
+        nullable: false,
+        values: [],
+        valuePositionLabels: []
+      } as unknown as VariableInfo
+    ]);
+    schemerService.setCodingScheme({
+      variableCodings: [
+        {
+          id: 'BASE_ID',
+          alias: 'INPUT',
+          sourceType: 'BASE',
+          codes: [code]
+        } as unknown as VariableCodingData,
+        {
+          id: 'OTHER_ID',
+          alias: 'OTHER',
+          sourceType: 'BASE',
+          codes: [code]
+        } as unknown as VariableCodingData,
+        {
+          id: 'DERIVED_ID',
+          alias: 'BASE_ID',
+          sourceType: 'COPY_VALUE',
+          deriveSources: ['OTHER_ID'],
+          codes: [code]
+        } as unknown as VariableCodingData
+      ]
+    } as unknown as never);
+
+    component.updateVariableLists();
+
+    expect(component.problems).toEqual(jasmine.arrayContaining([
+      jasmine.objectContaining({
+        type: 'INVALID_SOURCE',
+        breaking: true,
+        variableId: 'BASE_ID'
+      })
+    ]));
+    expect(component.codingStatus['BASE_ID']).toBe('OK');
+    expect(component.codingStatus['DERIVED_ID']).toBe('ERROR');
+  });
+
   it('updateVariableLists should compute codingStatus ERROR/WARNING based on validate() problems', () => {
     const schemeVars: VariableCodingData[] = [
       {


### PR DESCRIPTION
## Summary
- Update `@iqb/responses` from `^5.1.0` to `^5.2.0` in the workspace and library peer dependency.
- Refresh `package-lock.json` for the 5.2.0 package tarball.
- Add regression coverage for allowed derived/base alias shadowing and real alias/id collisions in Schemer and Scheme Checker flows.

## Context
Addresses #183. Version 5.2.0 includes the alias-shadowing validation/coding behavior needed by Schemer and Scheme Checker.

## Validation
- `npx eslint -c .eslintrc.cjs src projects --ext .ts,.js --no-cache --ignore-pattern '**/karma.conf.js'`
- `npm test` (`test:cc`: 314 successful, `test:schemer`: 6 successful)

Note: Local untracked `design/` was left out of this PR.