### PR TITLE
Validate cyclic derivations

### DIFF
--- a/projects/ngx-coding-components/src/lib/dialogs/show-coding-problems-dialog.component.ts
+++ b/projects/ngx-coding-components/src/lib/dialogs/show-coding-problems-dialog.component.ts
@@ -2,9 +2,9 @@ import { Component, Inject } from '@angular/core';
 import {
   MAT_DIALOG_DATA, MatDialogTitle, MatDialogContent, MatDialogActions, MatDialogClose
 } from '@angular/material/dialog';
-import { CodingSchemeProblem } from '@iqb/responses';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatButton } from '@angular/material/button';
+import { CodingSchemeValidationProblem } from '../services/coding-scheme-validation';
 
 @Component({
   template: `
@@ -46,9 +46,11 @@ import { MatButton } from '@angular/material/button';
   imports: [MatDialogTitle, MatDialogContent, MatDialogActions, MatButton, MatDialogClose, TranslateModule]
 })
 export class ShowCodingProblemsDialogComponent {
-  codingProblemsGrouped: { [ key: string]: CodingSchemeProblem[] } = {};
+  codingProblemsGrouped: { [ key: string]: CodingSchemeValidationProblem[] } = {};
   allVariables: string[];
-  constructor(@Inject(MAT_DIALOG_DATA) private codingProblems: CodingSchemeProblem[]) {
+  constructor(
+    @Inject(MAT_DIALOG_DATA) private codingProblems: CodingSchemeValidationProblem[]
+  ) {
     const allVariables: string[] = [];
     codingProblems.forEach(p => {
       if (allVariables.indexOf(p.variableId) < 0) allVariables.push(p.variableId);

--- a/projects/ngx-coding-components/src/lib/schemer/schemer.component.ts
+++ b/projects/ngx-coding-components/src/lib/schemer/schemer.component.ts
@@ -6,7 +6,6 @@ import {
   Output,
   ViewChild
 } from '@angular/core';
-import { CodingSchemeFactory, CodingSchemeProblem } from '@iqb/responses';
 import {
   BehaviorSubject,
   debounceTime,
@@ -59,6 +58,10 @@ import {
 import { SchemerFacadeService } from '../services/schemer-facade.service';
 import { parseVarListInput } from '../services/schemer-varlist-utils';
 import { SchemerInfoDialogComponent } from '../dialogs/schemer-info-dialog.component';
+import {
+  CodingSchemeValidationProblem,
+  validateCodingScheme
+} from '../services/coding-scheme-validation';
 
 @Component({
   selector: 'iqb-schemer',
@@ -136,7 +139,7 @@ export class SchemerComponent implements OnDestroy {
   derivedVariables: VariableCodingData[] = [];
   codingStatus: { [id: string]: string } = {};
   selectedCoding$ = new BehaviorSubject<VariableCodingData | null>(null);
-  problems: CodingSchemeProblem[] = [];
+  problems: CodingSchemeValidationProblem[] = [];
   hasVarListDuplicateConflict = false;
   varCodingChangedSubscription: Subscription | null = null;
 
@@ -283,13 +286,13 @@ export class SchemerComponent implements OnDestroy {
       this.schemerService.codingScheme.variableCodings
     ) {
       try {
-        this.problems = CodingSchemeFactory.validate(
+        this.problems = validateCodingScheme(
           this.schemerService.varList,
           this.schemerService.codingScheme.variableCodings
         );
       } catch (e) {
         // eslint-disable-next-line no-console
-        console.error('CodingSchemeFactory.validate failed', e);
+        console.error('validateCodingScheme failed', e);
         this.problems = [];
       }
       this.schemerService.codingScheme.variableCodings.forEach(v => {

--- a/projects/ngx-coding-components/src/lib/services/coding-scheme-validation.spec.ts
+++ b/projects/ngx-coding-components/src/lib/services/coding-scheme-validation.spec.ts
@@ -1,0 +1,103 @@
+import { CodingSchemeFactory, CodingSchemeProblem } from '@iqb/responses';
+import { VariableCodingData } from '@iqbspecs/coding-scheme/coding-scheme.interface';
+import {
+  CYCLIC_DERIVATION_PROBLEM_TYPE,
+  getCyclicDerivationProblems,
+  validateCodingScheme
+} from './coding-scheme-validation';
+
+describe('coding scheme validation', () => {
+  const derivedCoding = (
+    id: string,
+    deriveSources: string[],
+    alias?: string
+  ): VariableCodingData => ({
+    id,
+    alias,
+    sourceType: 'SUM_SCORE',
+    deriveSources
+  } as VariableCodingData);
+
+  it('should append cyclic derivation problems to factory validation problems', () => {
+    const existingProblems: CodingSchemeProblem[] = [
+      {
+        type: 'SOURCE_MISSING',
+        breaking: true,
+        variableId: 'missing',
+        variableLabel: ''
+      }
+    ];
+    spyOn(CodingSchemeFactory, 'validate').and.returnValue(existingProblems);
+
+    const problems = validateCodingScheme([], [
+      derivedCoding('A', ['A'], 'AliasA')
+    ]);
+
+    expect(problems).toEqual([
+      ...existingProblems,
+      {
+        type: CYCLIC_DERIVATION_PROBLEM_TYPE,
+        breaking: true,
+        variableId: 'AliasA',
+        variableLabel: ''
+      }
+    ]);
+  });
+
+  it('should detect direct cyclic derivations', () => {
+    const problems = getCyclicDerivationProblems([
+      derivedCoding('A', ['A'])
+    ]);
+
+    expect(problems).toEqual([
+      {
+        type: CYCLIC_DERIVATION_PROBLEM_TYPE,
+        breaking: true,
+        variableId: 'A',
+        variableLabel: ''
+      }
+    ]);
+  });
+
+  it('should detect all variables in an indirect cyclic derivation', () => {
+    const problems = getCyclicDerivationProblems([
+      { id: 'base', sourceType: 'BASE' } as VariableCodingData,
+      derivedCoding('A', ['B']),
+      derivedCoding('B', ['C']),
+      derivedCoding('C', ['A']),
+      derivedCoding('D', ['A'])
+    ]);
+
+    expect(problems.map(problem => problem.variableId)).toEqual([
+      'A',
+      'B',
+      'C'
+    ]);
+    expect(problems.every(problem => problem.breaking)).toBeTrue();
+    expect(problems.every(
+      problem => problem.type === CYCLIC_DERIVATION_PROBLEM_TYPE
+    )).toBeTrue();
+  });
+
+  it('should resolve unique aliases in derivation sources', () => {
+    const problems = getCyclicDerivationProblems([
+      derivedCoding('idA', ['AliasB'], 'AliasA'),
+      derivedCoding('idB', ['AliasA'], 'AliasB')
+    ]);
+
+    expect(problems.map(problem => problem.variableId)).toEqual([
+      'AliasA',
+      'AliasB'
+    ]);
+  });
+
+  it('should not report acyclic derivations', () => {
+    const problems = getCyclicDerivationProblems([
+      { id: 'base', sourceType: 'BASE' } as VariableCodingData,
+      derivedCoding('A', ['base']),
+      derivedCoding('B', ['A'])
+    ]);
+
+    expect(problems).toEqual([]);
+  });
+});

--- a/projects/ngx-coding-components/src/lib/services/coding-scheme-validation.ts
+++ b/projects/ngx-coding-components/src/lib/services/coding-scheme-validation.ts
@@ -1,0 +1,108 @@
+import { CodingSchemeFactory, CodingSchemeProblem } from '@iqb/responses';
+import { VariableCodingData } from '@iqbspecs/coding-scheme/coding-scheme.interface';
+import { VariableInfo } from '@iqbspecs/variable-info/variable-info.interface';
+
+export const CYCLIC_DERIVATION_PROBLEM_TYPE = 'CYCLIC_DERIVATION';
+
+export type CodingSchemeValidationProblemType =
+  CodingSchemeProblem['type'] | typeof CYCLIC_DERIVATION_PROBLEM_TYPE;
+
+export interface CodingSchemeValidationProblem extends
+  Omit<CodingSchemeProblem, 'type'> {
+  type: CodingSchemeValidationProblemType;
+}
+
+const isDerivedVariable = (coding: VariableCodingData): boolean => (
+  coding.sourceType !== 'BASE' && coding.sourceType !== 'BASE_NO_VALUE'
+);
+
+const getProblemVariableId = (coding: VariableCodingData): string => (
+  coding.alias || coding.id
+);
+
+const createCodingResolver = (
+  variableCodings: VariableCodingData[]
+): ((reference: string) => VariableCodingData | undefined) => {
+  const codingsById = new Map<string, VariableCodingData>();
+  const codingsByAlias = new Map<string, VariableCodingData[]>();
+
+  variableCodings.forEach(coding => {
+    codingsById.set(coding.id, coding);
+    if (coding.alias) {
+      codingsByAlias.set(coding.alias, [
+        ...(codingsByAlias.get(coding.alias) || []),
+        coding
+      ]);
+    }
+  });
+
+  return (reference: string): VariableCodingData | undefined => {
+    const codingById = codingsById.get(reference);
+    if (codingById) return codingById;
+
+    const codingsForAlias = codingsByAlias.get(reference) || [];
+    return codingsForAlias.length === 1 ? codingsForAlias[0] : undefined;
+  };
+};
+
+export const getCyclicDerivationProblems = (
+  variableCodings: VariableCodingData[]
+): CodingSchemeValidationProblem[] => {
+  const resolveCoding = createCodingResolver(variableCodings);
+  const visitState = new Map<string, 'visiting' | 'visited'>();
+  const path: string[] = [];
+  const cyclicCodingIds = new Set<string>();
+
+  const markCycle = (cycleStartCodingId: string): void => {
+    const cycleStartIndex = path.indexOf(cycleStartCodingId);
+    if (cycleStartIndex < 0) return;
+
+    path.slice(cycleStartIndex).forEach(codingId => {
+      cyclicCodingIds.add(codingId);
+    });
+  };
+
+  const visitCoding = (coding: VariableCodingData): void => {
+    const currentState = visitState.get(coding.id);
+    if (currentState === 'visiting') {
+      markCycle(coding.id);
+      return;
+    }
+
+    if (currentState === 'visited') return;
+
+    visitState.set(coding.id, 'visiting');
+    path.push(coding.id);
+
+    (coding.deriveSources || []).forEach(sourceReference => {
+      const sourceCoding = resolveCoding(sourceReference);
+      if (sourceCoding && isDerivedVariable(sourceCoding)) {
+        visitCoding(sourceCoding);
+      }
+    });
+
+    path.pop();
+    visitState.set(coding.id, 'visited');
+  };
+
+  variableCodings
+    .filter(isDerivedVariable)
+    .forEach(visitCoding);
+
+  return variableCodings
+    .filter(coding => cyclicCodingIds.has(coding.id))
+    .map(coding => ({
+      type: CYCLIC_DERIVATION_PROBLEM_TYPE,
+      breaking: true,
+      variableId: getProblemVariableId(coding),
+      variableLabel: coding.label || ''
+    }));
+};
+
+export const validateCodingScheme = (
+  baseVariables: VariableInfo[],
+  variableCodings: VariableCodingData[]
+): CodingSchemeValidationProblem[] => [
+  ...CodingSchemeFactory.validate(baseVariables, variableCodings),
+  ...getCyclicDerivationProblems(variableCodings)
+];

--- a/projects/ngx-coding-components/src/lib/translations/de.json
+++ b/projects/ngx-coding-components/src/lib/translations/de.json
@@ -488,6 +488,7 @@
     "RULESET_VALUE_ARRAY_POS_INVALID": "Ungültige Position im Werte-Array im Regelsatz.",
     "ONLY_ONE_SOURCE": "Eine Ableitung sollte mehr als eine Quelle haben.",
     "VALUE_COPY_NOT_FROM_BASE": "Es wurde ein Wert kopiert, aber nicht von einer Basisvariablen.",
-    "MORE_THAN_ONE_SOURCE": "Es wurde ein Wert kopiert, aber es gibt mehr als eine Quelle."
+    "MORE_THAN_ONE_SOURCE": "Es wurde ein Wert kopiert, aber es gibt mehr als eine Quelle.",
+    "CYCLIC_DERIVATION": "Zyklische Ableitung: Diese Variable ist Teil eines Ableitungszyklus."
   }
 }

--- a/src/assets/de.json
+++ b/src/assets/de.json
@@ -264,6 +264,7 @@
     "RULESET_VALUE_ARRAY_POS_INVALID": "Ungültige Position im Werte-Array im Regelsatz",
     "ONLY_ONE_SOURCE": "Eine Ableitung sollte mehr als eine Quelle haben",
     "VALUE_COPY_NOT_FROM_BASE": "Es wurde ein Wert kopiert, aber nicht von einer Basisvariablen.",
-    "MORE_THAN_ONE_SOURCE": "Es wurde ein Wert kopiert, aber es gibt mehr als eine Quelle."
+    "MORE_THAN_ONE_SOURCE": "Es wurde ein Wert kopiert, aber es gibt mehr als eine Quelle.",
+    "CYCLIC_DERIVATION": "Zyklische Ableitung: Diese Variable ist Teil eines Ableitungszyklus."
   }
 }


### PR DESCRIPTION
## Summary

- add central validation for direct and indirect cyclic derivations
- surface cyclic derivations in the coding problems dialog without mutating imported schemas
- add focused unit tests and German problem text

## Context

Refs #194. Imported or externally generated coding schemes can contain derivation cycles even though the UI prevents creating new ones. This change reports the affected variables as breaking validation problems.

## Validation

- `npx eslint -c .eslintrc.cjs projects/ngx-coding-components/src/lib/services/coding-scheme-validation.ts projects/ngx-coding-components/src/lib/services/coding-scheme-validation.spec.ts projects/ngx-coding-components/src/lib/schemer/schemer.component.ts projects/ngx-coding-components/src/lib/dialogs/show-coding-problems-dialog.component.ts projects/ngx-coding-components/src/lib/dialogs/show-coding-problems-dialog.component.spec.ts --ext .ts`
- `npx ng test ngx-coding-components --watch=false --browsers=ChromeHeadless --include=projects/ngx-coding-components/src/lib/services/coding-scheme-validation.spec.ts --include=projects/ngx-coding-components/src/lib/dialogs/show-coding-problems-dialog.component.spec.ts`
- `npx ng build ngx-coding-components`
- `npm run test:cc`