### PR TITLE
Keep math-table residual instructions editable

### DIFF
--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/generate-coding-dialog.component.spec.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/generate-coding-dialog.component.spec.ts
@@ -228,6 +228,35 @@ describe('GenerateCodingDialogComponent', () => {
     expect(residualAuto).toBeDefined();
   });
 
+  it('generateButtonClick should keep manual math-table residual instructions editable', () => {
+    const { component, dialogRef, schemerService } = createComponent({
+      type: 'json',
+      format: 'math-table'
+    });
+
+    component.mathTableExpectedResult = '579';
+    component.elseMethod = 'instruction';
+
+    schemerService.addCode.and.callFake((codes: CodeData[], type: CodeType) => {
+      const code = {
+        id: type === 'RESIDUAL' ? 0 : codes.length + 1,
+        type
+      } as CodeData;
+      codes.push(code);
+      return code;
+    });
+
+    component.generateButtonClick();
+
+    const closed = (dialogRef.close as jasmine.Spy).calls.mostRecent().args[0] as unknown as
+      { codeModel: string; codes: CodeData[] };
+    const residual = closed.codes.find(c => c.type === 'RESIDUAL');
+
+    expect(closed.codeModel).toBe('MANUAL_AND_RULES');
+    expect(residual).toBeDefined();
+    expect(closed.codes.find(c => c.type === 'RESIDUAL_AUTO')).toBeUndefined();
+  });
+
   it('generateButtonClick should generate manual math-table code structure without rules', () => {
     const { component, dialogRef, schemerService } = createComponent({
       type: 'json',

--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/generate-coding-dialog.component.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/generate-coding-dialog.component.ts
@@ -554,7 +554,9 @@ export class GenerateCodingDialogComponent {
       return;
     }
 
-    newVardata.codeModel = 'RULES_ONLY';
+    newVardata.codeModel = this.elseMethod === 'instruction' ?
+      'MANUAL_AND_RULES' :
+      'RULES_ONLY';
     newVardata.manualInstruction = '';
 
     if (


### PR DESCRIPTION
## Summary

- keep manually entered MathTable residual instructions editable
- use `MANUAL_AND_RULES` when the residual method is `instruction`
- add regression coverage for the generated coding model

## Root cause

The MathTable generator always forced `RULES_ONLY` after generation, even when a manual residual instruction had been selected.

## Validation

- targeted `generate-coding-dialog.component.spec.ts`: 27 tests passed
- Angular package build completed successfully