### PR TITLE
Align package metadata with 3.1.2

### DIFF
--- a/projects/ngx-coding-components/ng-package.json
+++ b/projects/ngx-coding-components/ng-package.json
@@ -1,6 +1,10 @@
 {
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
   "dest": "../../dist/ngx-coding-components",
+  "allowedNonPeerDependencies": [
+    "@iqb/mathlive",
+    "katex"
+  ],
   "lib": {
     "entryFile": "src/public-api.ts"
   }

--- a/projects/ngx-coding-components/package.json
+++ b/projects/ngx-coding-components/package.json
@@ -4,7 +4,7 @@
   "exports": {
     "./lib/ngx-coding-components.module": "./lib/ngx-coding-components.module.d.ts"
   },
-  "version": "3.1.0",
+  "version": "3.1.2",
   "author": "IQB - Institut zur Qualitätsentwicklung im Bildungswesen",
   "license": "MIT",
   "description": "Angular components for coding responses in assessments of IQB.",
@@ -70,6 +70,8 @@
     "typescript": "5.8.3"
   },
   "dependencies": {
+    "@iqb/mathlive": "^0.4.1",
+    "katex": "^0.16.11",
     "tslib": "^2.3.0"
   },
   "sideEffects": false


### PR DESCRIPTION
## Summary

- align the source package version with the already published `@iqb/ngx-coding-components@3.1.2`
- package `@iqb/mathlive` and `katex` as runtime dependencies
- allow both runtime dependencies in the ng-packagr configuration

## Why

The npm package is already published as version `3.1.2`, but the checked-in package metadata still reports `3.1.0` and does not describe the packaged MathLive and KaTeX dependencies.

## Validation

- Angular package build completed successfully
- generated package manifest reports version `3.1.2`
- generated package manifest contains `@iqb/mathlive@^0.4.1` and `katex@^0.16.11`