### PR TITLE
Prepare Schemer 2.8.0 packaging metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coding-components",
   "config": {
-    "schemer_version": "2.7.0"
+    "schemer_version": "2.8.0"
   },
   "scripts": {
     "ng": "ng",

--- a/projects/schemer/src/html_wrapper/index.html
+++ b/projects/schemer/src/html_wrapper/index.html
@@ -24,7 +24,7 @@
         "de": "Dieser Schemer erlaubt die Definition eines Coding Scheme iqb-standard@3.2",
         "en": "This schemer is for editing coding schemes of type iqb-standard@3.2"
       },
-      "version": "2.7.0",
+      "version": "version-placeholder",
       "apiVersion": "3.4.1",
       "repository": {
         "type": "git",


### PR DESCRIPTION
## Summary

- set the Schemer packaging version to `2.8.0`
- replace the fixed wrapper version with the packaging placeholder
- let the packaging script inject the configured version into the Verona metadata

## Why

The wrapper still contained a fixed `2.7.0` value. Using the existing placeholder mechanism keeps the configured Schemer version and the generated HTML artifact consistent.

## Validation

- Schemer application build completed successfully
- packaging completed successfully
- generated `iqb-schemer@2.8.0.html` reports version `2.8.0`
- generated artifact reports API version `3.4.1`
- generated artifact SHA-256: `f24c33de4d3487768bf263f0f70a33ecc88174a0fee6593ee44f482c0575e621`

This PR does not modify the existing GitHub release, tag, or release assets.