### PR TITLE
Allow alias and ID overlaps in Schemer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/platform-browser-dynamic": "^20.3.25",
         "@angular/router": "^20.3.25",
         "@iqb/mathlive": "^0.4.1",
-        "@iqb/responses": "^5.2.0",
+        "@iqb/responses": "^5.2.1",
         "@iqbspecs/coding-scheme": "^3.4.1",
         "@iqbspecs/response": "^2.0.0",
         "@iqbspecs/validate-json": "^0.4.0",
@@ -3645,9 +3645,9 @@
       }
     },
     "node_modules/@iqb/responses": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@iqb/responses/-/responses-5.2.0.tgz",
-      "integrity": "sha512-Pk1s0CFA/SeAdns/RdHEKMSt/WhHYRzM7jkU7p5n/Nt+1Hpwj4zkvS8uXfofNplYhV7lkeMes1kcceqqQ2fekw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@iqb/responses/-/responses-5.2.1.tgz",
+      "integrity": "sha512-9uXJxQjI32iUmZBzxyjpGlrxTJPZX+RcBjDmS2TCks0knWhHqa53wBOnRiWkSmy5iWqo8tMsKsuyqwVe6reCSg==",
       "license": "CC0 1.0",
       "dependencies": {
         "mathjs": "^12.4.2"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@angular/platform-browser-dynamic": "^20.3.25",
     "@angular/router": "^20.3.25",
     "@iqb/mathlive": "^0.4.1",
-    "@iqb/responses": "^5.2.0",
+    "@iqb/responses": "^5.2.1",
     "@iqbspecs/coding-scheme": "^3.4.1",
     "@iqbspecs/response": "^2.0.0",
     "@iqbspecs/validate-json": "^0.4.0",

--- a/projects/ngx-coding-components/src/lib/dialogs/resolve-varlist-duplicates-dialog.component.spec.ts
+++ b/projects/ngx-coding-components/src/lib/dialogs/resolve-varlist-duplicates-dialog.component.spec.ts
@@ -63,18 +63,16 @@ describe('ResolveVarListDuplicatesDialogComponent', () => {
     expect(component.invalidAliasCount).toBe(0);
   });
 
-  it('should mark alias/id collisions', () => {
+  it('should allow unique aliases matching other ids', () => {
     const { component } = createComponent({
       varList: [
-        { id: 'likert-row_4', alias: '01a' },
-        { id: '01a', alias: '05a' }
+        { id: '04', alias: '02' },
+        { id: '02', alias: '05' }
       ]
     });
 
-    expect(component.hasProblems).toBeTrue();
-    expect(component.aliasIdCollisionValues).toEqual(['01A']);
-    expect(component.isAliasIdCollisionAlias('01a')).toBeTrue();
-    expect(component.isAliasIdCollisionId('01a')).toBeTrue();
+    expect(component.hasProblems).toBeFalse();
+    expect(component.statusText).toBe('Keine Konflikte mehr.');
   });
 
   it('should not mutate the input varList', () => {

--- a/projects/ngx-coding-components/src/lib/dialogs/resolve-varlist-duplicates-dialog.component.ts
+++ b/projects/ngx-coding-components/src/lib/dialogs/resolve-varlist-duplicates-dialog.component.ts
@@ -24,7 +24,7 @@ export interface ResolveVarListDuplicatesDialogData {
 
     <mat-dialog-content>
       <div style="margin-bottom: 10px;">
-        Die Variablenliste enthält doppelte, ungültige oder kollidierende IDs/Aliase.
+        Die Variablenliste enthält doppelte oder ungültige IDs/Aliase.
         Bitte korrigiere die Variablenliste und lade den Schemer neu.
       </div>
 
@@ -41,8 +41,6 @@ export interface ResolveVarListDuplicatesDialogData {
         <div><b>Doppelte IDs:</b> {{ duplicateIdValues.join(', ') }}</div>
         } @if (duplicateAliasValues.length > 0) {
         <div><b>Doppelte Aliase:</b> {{ duplicateAliasValues.join(', ') }}</div>
-        } @if (aliasIdCollisionValues.length > 0) {
-        <div><b>Alias entspricht anderer ID:</b> {{ aliasIdCollisionValues.join(', ') }}</div>
         } @if (invalidIdCount > 0) {
         <div><b>Ungültige IDs:</b> {{ invalidIdCount }}</div>
         } @if (invalidAliasCount > 0) {
@@ -56,7 +54,6 @@ export interface ResolveVarListDuplicatesDialogData {
         <div
           style="flex: 1;"
           [class.duplicate-field]="isDuplicateId(v.id)"
-          [class.alias-id-field]="isAliasIdCollisionId(v.id)"
           [class.invalid-field]="isInvalidId(v.id)"
         >
           <b>ID:</b> {{ v.id || '-' }}
@@ -64,7 +61,6 @@ export interface ResolveVarListDuplicatesDialogData {
         <div
           style="flex: 1;"
           [class.duplicate-field]="isDuplicateAlias(v.alias || v.id)"
-          [class.alias-id-field]="isAliasIdCollisionAlias(v.alias || v.id)"
           [class.invalid-field]="isInvalidAlias(v.alias || v.id)"
         >
           <b>Alias:</b> {{ v.alias || v.id || '-' }}
@@ -85,7 +81,6 @@ export interface ResolveVarListDuplicatesDialogData {
   `,
   styles: [
     '.duplicate-field { outline: 2px solid #b00020; outline-offset: 2px; border-radius: 3px; padding: 4px; }',
-    '.alias-id-field { outline: 2px solid #c2185b; outline-offset: 2px; border-radius: 3px; padding: 4px; }',
     '.invalid-field { outline: 2px solid #ff6f00; outline-offset: 2px; border-radius: 3px; padding: 4px; }'
   ],
   standalone: true,
@@ -104,12 +99,9 @@ export class ResolveVarListDuplicatesDialogComponent {
 
   private duplicateIds = new Set<string>();
   private duplicateAliases = new Set<string>();
-  private aliasIdCollisionAliases = new Set<string>();
-  private aliasIdCollisionIds = new Set<string>();
 
   duplicateIdValues: string[] = [];
   duplicateAliasValues: string[] = [];
-  aliasIdCollisionValues: string[] = [];
   invalidIdCount = 0;
   invalidAliasCount = 0;
 
@@ -126,11 +118,8 @@ export class ResolveVarListDuplicatesDialogComponent {
 
     this.duplicateIds = analysis.duplicateIds;
     this.duplicateAliases = analysis.duplicateAliases;
-    this.aliasIdCollisionAliases = analysis.aliasIdCollisionAliases;
-    this.aliasIdCollisionIds = analysis.aliasIdCollisionIds;
     this.duplicateIdValues = analysis.duplicateIdValues;
     this.duplicateAliasValues = analysis.duplicateAliasValues;
-    this.aliasIdCollisionValues = analysis.aliasIdCollisionValues;
     this.invalidIdCount = analysis.invalidIdCount;
     this.invalidAliasCount = analysis.invalidAliasCount;
     this.hasProblems = analysis.hasProblems;
@@ -146,9 +135,6 @@ export class ResolveVarListDuplicatesDialogComponent {
       if (analysis.hasDuplicateAlias) {
         problems.push('Doppelte Aliase');
       }
-      if (analysis.hasAliasIdCollision) {
-        problems.push('Alias entspricht anderer ID');
-      }
       this.statusText = problems.join(' | ');
     } else {
       this.statusText = 'Keine Konflikte mehr.';
@@ -163,16 +149,6 @@ export class ResolveVarListDuplicatesDialogComponent {
   isDuplicateAlias(value: string | null | undefined): boolean {
     const key = (value || '').trim().toUpperCase();
     return !!key && this.duplicateAliases.has(key);
-  }
-
-  isAliasIdCollisionId(value: string | null | undefined): boolean {
-    const key = (value || '').trim().toUpperCase();
-    return !!key && this.aliasIdCollisionIds.has(key);
-  }
-
-  isAliasIdCollisionAlias(value: string | null | undefined): boolean {
-    const key = (value || '').trim().toUpperCase();
-    return !!key && this.aliasIdCollisionAliases.has(key);
   }
 
   isInvalidId = isInvalidVarListId;

--- a/projects/ngx-coding-components/src/lib/schemer/schemer.component.spec.ts
+++ b/projects/ngx-coding-components/src/lib/schemer/schemer.component.spec.ts
@@ -344,7 +344,7 @@ describe('SchemerComponent', () => {
     expect(component.codingStatus['DERIVED_ID']).toBe('OK');
   });
 
-  it('updateVariableLists should keep reporting real alias/id collisions', () => {
+  it('updateVariableLists should allow unique aliases matching other ids', () => {
     const code = {
       id: 1,
       type: 'FULL_CREDIT',
@@ -401,15 +401,9 @@ describe('SchemerComponent', () => {
 
     component.updateVariableLists();
 
-    expect(component.problems).toEqual(jasmine.arrayContaining([
-      jasmine.objectContaining({
-        type: 'INVALID_SOURCE',
-        breaking: true,
-        variableId: 'BASE_ID'
-      })
-    ]));
+    expect(component.problems).toEqual([]);
     expect(component.codingStatus['BASE_ID']).toBe('OK');
-    expect(component.codingStatus['DERIVED_ID']).toBe('ERROR');
+    expect(component.codingStatus['DERIVED_ID']).toBe('OK');
   });
 
   it('updateVariableLists should compute codingStatus ERROR/WARNING based on validate() problems', () => {

--- a/projects/ngx-coding-components/src/lib/services/schemer-facade.service.spec.ts
+++ b/projects/ngx-coding-components/src/lib/services/schemer-facade.service.spec.ts
@@ -90,6 +90,18 @@ describe('SchemerFacadeService', () => {
     expect(dialog.open).not.toHaveBeenCalled();
   });
 
+  it('tryResolveVarListDuplicates should allow unique aliases matching other ids', () => {
+    const service = createService();
+
+    schemerService.setVarList([
+      { id: '04', alias: '02' } as never,
+      { id: '02', alias: '05' } as never
+    ]);
+
+    expect(service.tryResolveVarListDuplicates()).toBeFalse();
+    expect(dialog.open).not.toHaveBeenCalled();
+  });
+
   it('tryResolveVarListDuplicates should open dialog when invalid ids or aliases exist', () => {
     const service = createService();
 

--- a/projects/ngx-coding-components/src/lib/services/schemer-varlist-validation.spec.ts
+++ b/projects/ngx-coding-components/src/lib/services/schemer-varlist-validation.spec.ts
@@ -52,17 +52,15 @@ describe('schemer-varlist-validation', () => {
     expect(analysis.invalidAliasCount).toBe(1);
   });
 
-  it('getVarListConflictAnalysis should detect alias/id collisions', () => {
+  it('getVarListConflictAnalysis should allow unique aliases matching other ids', () => {
     const analysis = getVarListConflictAnalysis([
-      { id: 'likert-row_4', alias: '01a' },
-      { id: '01a', alias: '05a' },
-      { id: 'likert-row_5', alias: '01b' },
-      { id: '01b', alias: '05b' }
+      { id: '04', alias: '02' },
+      { id: '02', alias: '05' }
     ] as VariableInfo[]);
 
-    expect(analysis.hasProblems).toBeTrue();
-    expect(analysis.hasAliasIdCollision).toBeTrue();
-    expect(analysis.aliasIdCollisionValues).toEqual(['01A', '01B']);
+    expect(analysis.hasProblems).toBeFalse();
+    expect(analysis.hasDuplicateId).toBeFalse();
+    expect(analysis.hasDuplicateAlias).toBeFalse();
     expect(analysis.invalidIdCount).toBe(0);
     expect(analysis.invalidAliasCount).toBe(0);
   });

--- a/projects/ngx-coding-components/src/lib/services/schemer-varlist-validation.ts
+++ b/projects/ngx-coding-components/src/lib/services/schemer-varlist-validation.ts
@@ -7,16 +7,12 @@ export type VarListConflictAnalysis = {
   signature: string;
   duplicateIds: Set<string>;
   duplicateAliases: Set<string>;
-  aliasIdCollisionAliases: Set<string>;
-  aliasIdCollisionIds: Set<string>;
   duplicateIdValues: string[];
   duplicateAliasValues: string[];
-  aliasIdCollisionValues: string[];
   invalidIdCount: number;
   invalidAliasCount: number;
   hasDuplicateId: boolean;
   hasDuplicateAlias: boolean;
-  hasAliasIdCollision: boolean;
   hasInvalid: boolean;
   hasProblems: boolean;
 };
@@ -76,20 +72,6 @@ export const getVarListConflictAnalysis = (
       .map(([k]) => k)
   );
 
-  const idKeys = new Set(
-    varList.map(v => normaliseKey(v.id)).filter(v => !!v)
-  );
-  const aliasIdCollisionAliases = new Set<string>();
-  const aliasIdCollisionIds = new Set<string>();
-  varList.forEach(v => {
-    const idKey = normaliseKey(v.id);
-    const aliasKey = normaliseKey(v.alias || v.id);
-    if (aliasKey && idKey && aliasKey !== idKey && idKeys.has(aliasKey)) {
-      aliasIdCollisionAliases.add(aliasKey);
-      aliasIdCollisionIds.add(aliasKey);
-    }
-  });
-
   const invalidIdCount = varList.filter(v => isInvalidVarListId(v.id))
     .length;
   const invalidAliasCount = varList.filter(v => (
@@ -98,26 +80,19 @@ export const getVarListConflictAnalysis = (
 
   const hasDuplicateId = duplicateIds.size > 0;
   const hasDuplicateAlias = duplicateAliases.size > 0;
-  const hasAliasIdCollision = aliasIdCollisionAliases.size > 0;
   const hasInvalid = invalidIdCount > 0 || invalidAliasCount > 0;
 
   return {
     signature,
     duplicateIds,
     duplicateAliases,
-    aliasIdCollisionAliases,
-    aliasIdCollisionIds,
     duplicateIdValues: Array.from(duplicateIds.values()).sort(),
     duplicateAliasValues: Array.from(duplicateAliases.values()).sort(),
-    aliasIdCollisionValues: Array.from(aliasIdCollisionAliases.values())
-      .sort(),
     invalidIdCount,
     invalidAliasCount,
     hasDuplicateId,
     hasDuplicateAlias,
-    hasAliasIdCollision,
     hasInvalid,
-    hasProblems: hasDuplicateId || hasDuplicateAlias ||
-      hasAliasIdCollision || hasInvalid
+    hasProblems: hasDuplicateId || hasDuplicateAlias || hasInvalid
   };
 };


### PR DESCRIPTION
## Summary

- remove alias-to-foreign-ID overlaps from Schemer variable-list conflict analysis
- remove the corresponding blocking dialog content and highlighting
- add regression coverage for `id=04, alias=02` beside `id=02, alias=05`
- retain duplicate-ID, duplicate-alias, and invalid-name conflicts
- require `@iqb/responses@^5.2.1`

## Root cause

Schemer treated public aliases and internal technical IDs as a shared namespace and blocked valid variable lists before editing. The Responses validator previously reported the same overlap as `INVALID_SOURCE`.

## Dependency

iqb-berlin/responses#102 is merged and `@iqb/responses@5.2.1` is published. This PR now locks that corrected version. No generic `INVALID_SOURCE` filtering is included.

## Validation

- coding-components unit tests — 329 passed
- Schemer tests — 6 passed
- `npm run lint`
- `npm run build_cc`