### PR TITLE
Prepare Schemer 2.8.1 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coding-components",
   "config": {
-    "schemer_version": "2.8.0"
+    "schemer_version": "2.8.1"
   },
   "scripts": {
     "ng": "ng",


### PR DESCRIPTION
## Änderung

- setzt die Schemer-Paketversion von 2.8.0 auf 2.8.1
- veröffentlicht damit die bereits zusammengeführten Korrekturen für Alias/ID-Überlappungen und `@iqb/responses` 5.2.1
- lässt `@iqbspecs/response`, die Bibliotheksversion 3.1.2 und den dynamischen Metadaten-Platzhalter unverändert

## Auswirkung

Das erzeugte Verona-Modul weist Version 2.8.1 und API-Version 3.4.1 aus. Eindeutige Aliase dürfen IDs anderer Variablen entsprechen; echte Duplikate und ungültige Werte bleiben Fehler.

## Prüfung

- `npm ci`
- `npm run audit:prod`
- `npm run lint`
- `npm run test:coverage` (329 Komponenten-Tests, 6 Schemer-Tests)
- `npm run buildAndPack_sc`
- Paketmetadaten und SHA-256 des lokalen Artefakts geprüft