### PR TITLE
Suppress residual warning for solver codes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10267,9 +10267,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
   "overrides": {
     "@babel/core": "7.29.7",
     "esbuild": "0.28.1",
+    "fast-uri": "3.1.4",
     "vite": "7.3.5"
   },
   "eslintConfig": {

--- a/projects/ngx-coding-components/src/lib/var-coding/single-code.component.spec.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/single-code.component.spec.ts
@@ -64,4 +64,20 @@ describe('SingleCodeComponent', () => {
     expect(component.showSideInstruction()).toBeTrue();
     expect(component.suppressResidualAutoWarning()).toBeTrue();
   });
+
+  it('should suppress the RESIDUAL_AUTO warning for all codes in SOLVER codings', () => {
+    component.code = {
+      id: 1,
+      type: 'FULL_CREDIT',
+      label: '',
+      score: 1,
+      manualInstruction: '<p>instruction</p>'
+    } as unknown as CodeData;
+
+    component.sourceType = 'BASE';
+    expect(component.suppressResidualAutoWarning()).toBeFalse();
+
+    component.sourceType = 'SOLVER';
+    expect(component.suppressResidualAutoWarning()).toBeTrue();
+  });
 });

--- a/projects/ngx-coding-components/src/lib/var-coding/single-code.component.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/single-code.component.ts
@@ -151,7 +151,7 @@ export class SingleCodeComponent {
   }
 
   suppressResidualAutoWarning(): boolean {
-    return this.code?.type === 'RESIDUAL_AUTO' && this.showResidualAutoManualInstruction();
+    return this.showResidualAutoManualInstruction();
   }
 
   setCodeInvalid() {


### PR DESCRIPTION
## Summary

Relates to #165. This PR intentionally does not close the issue.

- suppresses the residual-auto warning for all codes of a SOLVER variable
- keeps the warning unchanged for non-SOLVER variables
- adds a regression test for a regular code with manual instructions in a SOLVER coding

## Root cause

The warning suppression was calculated per code and only returned `true` when the current code itself was `RESIDUAL_AUTO`. Other codes of the same SOLVER variable therefore still displayed the warning even though their manual instructions can be used in the SOLVER-specific fallback case.

## Validation

- `npm run test:cc` — 330 tests passed
- `npm run lint`
- `git diff --check`
- UI matrix covering BASE and SOLVER variables, with and without `RESIDUAL_AUTO`, across `MANUAL_AND_RULES`, `MANUAL_ONLY`, and `RULES_ONLY`
- production Schemer build and bootstrap check