### PR TITLE
Support solver fragment policies in Schemer

### DIFF
--- a/projects/ngx-coding-components/src/lib/translations/de.json
+++ b/projects/ngx-coding-components/src/lib/translations/de.json
@@ -285,21 +285,25 @@
       "action": "Testen",
       "result": "Ergebnis",
       "no-sources": "Keine Quellvariable ausgewählt.",
+      "incomplete": "Kontrolliert unvollständiges Ergebnis (INC).",
       "error-expression-missing": "Bitte einen Solver-Ausdruck eingeben.",
       "error-sources-missing": "Bitte mindestens eine Quellvariable auswählen.",
       "error-unselected-source": "Der Ausdruck verweist auf nicht ausgewählte Quelle(n)",
       "error-invalid-value": "Bitte numerischen Testwert prüfen",
-      "error-evaluation": "Der Ausdruck konnte nicht ausgewertet werden. Bitte Syntax, Variablennamen und numerische Testwerte prüfen."
+      "error-evaluation": "Der Ausdruck konnte nicht ausgewertet werden. Bitte Syntax, Variablennamen und Testwerte prüfen."
     },
     "solver-help": {
       "title": "Syntaxhilfe für Solver-Ausdrücke",
-      "description": "Solver-Ausdrücke werden mit math.js ausgewertet. Verwenden Sie Zahlen, Rechenzeichen und math.js-Funktionen; Quellvariablen referenzieren Sie mit ${Variablenname} oder ${VariablenID}.",
+      "description": "Solver-Ausdrücke werden mit math.js ausgewertet. Quellvariablen referenzieren Sie mit ${Variablenname}; ${VAR[0]} greift auf das erste Fragment zu (Indizes beginnen bei 0).",
+      "policies": "Optional folgen Policies für leere/fehlende und nichtnumerische Werte: ${VAR[i]:Leer-Policy:Nichtnumerisch-Policy}. Erlaubt sind ERROR, INC oder ein numerischer Defaultwert.",
+      "fragment-mismatch": "Passt der Wert nicht auf die Fragmentierungs-Regex, gilt das Fragment als fehlend und die erste Policy wird verwendet.",
       "examples-title": "Beispiele:",
       "examples": {
         "arithmetic": "einfache Rechenoperationen",
         "variables": "Werte aus zwei Quellvariablen addieren",
         "function": "Prozentwert berechnen und runden",
-        "condition": "Bedingung: Ergebnis ist 1, wenn Punkte mindestens 5 sind, sonst 0"
+        "condition": "Bedingung: Ergebnis ist 1, wenn Punkte mindestens 5 sind, sonst 0",
+        "fragment-policies": "Bruchfragmente verwenden; fehlende oder nichtnumerische Fragmente ergeben CODING_INCOMPLETE"
       },
       "docs-link": "math.js-Syntax öffnen"
     }

--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.html
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.html
@@ -110,6 +110,7 @@
         @if (solverTestResult) {
           <div class="solver-test-result"
                [class.solver-test-result-ok]="solverTestResult.type === 'success'"
+               [class.solver-test-result-warning]="solverTestResult.type === 'warning'"
                [class.solver-test-result-error]="solverTestResult.type === 'error'">
             {{ solverTestResult.message }}
           </div>
@@ -124,6 +125,8 @@
           </span>
         </div>
         <p>{{ 'derive-processing.solver-help.description' | translate }}</p>
+        <p>{{ 'derive-processing.solver-help.policies' | translate }}</p>
+        <p>{{ 'derive-processing.solver-help.fragment-mismatch' | translate }}</p>
         <div>{{ 'derive-processing.solver-help.examples-title' | translate }}</div>
         <ul>
           @for (example of solverExpressionExamples; track example.expression) {

--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.spec.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.spec.ts
@@ -10,6 +10,8 @@ describe('EditSourceParametersDialog', () => {
 
   const translations: Record<string, string> = {
     'derive-processing.solver-test.result': 'Ergebnis',
+    'derive-processing.solver-test.incomplete':
+      'Kontrolliert unvollständiges Ergebnis (INC).',
     'derive-processing.solver-test.error-expression-missing': 'Bitte einen Solver-Ausdruck eingeben.',
     'derive-processing.solver-test.error-sources-missing': 'Bitte mindestens eine Quellvariable auswählen.',
     'derive-processing.solver-test.error-unselected-source': 'Der Ausdruck verweist auf nicht ausgewählte Quelle(n)',
@@ -289,6 +291,23 @@ describe('EditSourceParametersDialog', () => {
     expect(dialog.solverSourceWarning).toContain('V2');
   });
 
+  it('solverSourceWarning should recognize fragment and policy references', () => {
+    const dialog = createDialog({
+      selfAlias: 'D',
+      sourceType: 'SOLVER',
+      sourceParameters: {
+        solverExpression:
+          `${solverRef('V1')} + \${V2[0]} + \${V2[1]:INC} + \${V2[2]:0:INC}`
+      },
+      deriveSources: ['v1']
+    });
+
+    expect(dialog.solverSourceWarning).toContain(
+      'Warnung: Im Solver-Ausdruck referenzierte Variable(n)'
+    );
+    expect(dialog.solverSourceWarning).toContain('V2');
+  });
+
   it('solverSourceWarning should update when expression or source selection changes', () => {
     const dialog = createDialog({
       selfAlias: 'D',
@@ -365,7 +384,7 @@ describe('EditSourceParametersDialog', () => {
     );
   });
 
-  it('runSolverTest should report non-numeric test values', () => {
+  it('runSolverTest should report DERIVE_ERROR for non-numeric values without a policy', () => {
     const dialog = createDialog({
       selfAlias: 'D',
       sourceType: 'SOLVER',
@@ -376,11 +395,115 @@ describe('EditSourceParametersDialog', () => {
     dialog.solverTestValues['v1'] = 'abc';
     dialog.runSolverTest();
 
-    expect(dialog.solverTestResult?.type).toBe('error');
-    expect(dialog.solverTestResult?.message).toContain(
-      'Bitte numerischen Testwert prüfen'
-    );
-    expect(dialog.solverTestResult?.message).toContain('V1');
+    expect(dialog.solverTestResult).toEqual({
+      type: 'error',
+      message: 'Der Ausdruck konnte nicht ausgewertet werden.'
+    });
+  });
+
+  it('runSolverTest should let a non-numeric policy handle the raw source value', () => {
+    const dialog = createDialog({
+      selfAlias: 'D',
+      sourceType: 'SOLVER',
+      sourceParameters: {
+        solverExpression: `${solverRef('V1:ERROR:INC')} + 1`
+      },
+      deriveSources: ['v1']
+    });
+
+    dialog.solverTestValues['v1'] = 'abc';
+    dialog.runSolverTest();
+
+    expect(dialog.solverTestResult).toEqual({
+      type: 'warning',
+      message: 'Kontrolliert unvollständiges Ergebnis (INC).'
+    });
+  });
+
+  it('runSolverTest should evaluate numeric fragments from a formula source', () => {
+    const dialog = createDialog({
+      selfAlias: 'D',
+      sourceType: 'SOLVER',
+      sourceParameters: {
+        solverExpression:
+          `${solverRef('V1[1]')} - 2 * ${solverRef('V1[0]')}`
+      },
+      deriveSources: ['v1'],
+      codingScheme: {
+        variableCodings: [{
+          id: 'v1',
+          alias: 'V1',
+          sourceType: 'BASE',
+          fragmenting: '^\\\\frac\\{?(\\d+)\\}?\\{?(\\d+)\\}?$'
+        }]
+      }
+    });
+
+    dialog.solverTestValues['v1'] = '\\frac{1}{2}';
+    dialog.runSolverTest();
+
+    expect(dialog.solverTestResult).toEqual({
+      type: 'success',
+      message: 'Ergebnis: 0'
+    });
+  });
+
+  it('runSolverTest should report regex mismatches as incomplete with INC', () => {
+    const dialog = createDialog({
+      selfAlias: 'D',
+      sourceType: 'SOLVER',
+      sourceParameters: {
+        solverExpression:
+          `${solverRef('V1[1]:INC:INC')} - 2 * ${
+            solverRef('V1[0]:INC:INC')
+          }`
+      },
+      deriveSources: ['v1'],
+      codingScheme: {
+        variableCodings: [{
+          id: 'v1',
+          alias: 'V1',
+          sourceType: 'BASE',
+          fragmenting: '^\\\\frac\\{?(\\d+)\\}?\\{?(\\d+)\\}?$'
+        }]
+      }
+    });
+
+    dialog.solverTestValues['v1'] = '\\frac{1}{zwei}';
+    dialog.runSolverTest();
+
+    expect(dialog.solverTestResult).toEqual({
+      type: 'warning',
+      message: 'Kontrolliert unvollständiges Ergebnis (INC).'
+    });
+  });
+
+  it('runSolverTest should report regex mismatches as errors without a policy', () => {
+    const dialog = createDialog({
+      selfAlias: 'D',
+      sourceType: 'SOLVER',
+      sourceParameters: {
+        solverExpression:
+          `${solverRef('V1[1]')} - 2 * ${solverRef('V1[0]')}`
+      },
+      deriveSources: ['v1'],
+      codingScheme: {
+        variableCodings: [{
+          id: 'v1',
+          alias: 'V1',
+          sourceType: 'BASE',
+          fragmenting: '^\\\\frac\\{?(\\d+)\\}?\\{?(\\d+)\\}?$'
+        }]
+      }
+    });
+
+    dialog.solverTestValues['v1'] = '\\frac{1}{2}+1';
+    dialog.runSolverTest();
+
+    expect(dialog.solverTestResult).toEqual({
+      type: 'error',
+      message: 'Der Ausdruck konnte nicht ausgewertet werden.'
+    });
   });
 
   it('runSolverTest should report syntax and evaluation errors', () => {
@@ -432,5 +555,10 @@ describe('EditSourceParametersDialog', () => {
     expect(expressions.some(
       expression => expression.includes('?') && expression.includes(':')
     )).toBeTrue();
+    expect(expressions).toContain(
+      `${solverRef('FORMEL[1]:INC:INC')} - 2 * ${
+        solverRef('FORMEL[0]:INC:INC')
+      }`
+    );
   });
 });

--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.ts
@@ -30,7 +30,7 @@ import {
   VariableSourceParameters
 } from '@iqbspecs/coding-scheme/coding-scheme.interface';
 import { Response } from '@iqbspecs/response/response.interface';
-import { CodingFactory, CodingSchemeFactory } from '@iqb/responses';
+import { CodingSchemeFactory } from '@iqb/responses';
 import {
   SchemerService,
   VARIABLE_NAME_CHECK_PATTERN
@@ -45,7 +45,7 @@ export interface EditSourceParametersDialogData {
 }
 
 type SolverTestResult = {
-  type: 'success' | 'error';
+  type: 'success' | 'warning' | 'error';
   message: string;
 };
 
@@ -192,6 +192,11 @@ const SOLVER_VARIABLE_PREFIX = '$';
       color: #b71c1c;
     }
 
+    .solver-test-result-warning {
+      background: #fff8e1;
+      color: #5f3f00;
+    }
+
     .solver-test-hint {
       color: rgba(0, 0, 0, 0.6);
       margin-bottom: 8px;
@@ -247,6 +252,11 @@ export class EditSourceParametersDialog {
     {
       expression: `${SOLVER_VARIABLE_PREFIX}{Punkte} >= 5 ? 1 : 0`,
       descriptionKey: 'derive-processing.solver-help.examples.condition'
+    },
+    {
+      expression: `${SOLVER_VARIABLE_PREFIX}{FORMEL[1]:INC:INC} - 2 * ` +
+        `${SOLVER_VARIABLE_PREFIX}{FORMEL[0]:INC:INC}`,
+      descriptionKey: 'derive-processing.solver-help.examples.fragment-policies'
     }
   ];
 
@@ -456,23 +466,6 @@ export class EditSourceParametersDialog {
       return;
     }
 
-    const invalidNumericSources = referencedVariables.filter(
-      sourceId => CodingFactory.getValueAsNumber(
-        this.solverTestValues[sourceId] || ''
-      ) === null
-    );
-
-    if (invalidNumericSources.length > 0) {
-      this.solverTestResult = {
-        type: 'error',
-        message: `${this.tr(
-          'derive-processing.solver-test.error-invalid-value'
-        )}: ${invalidNumericSources.map(sourceId => this.getSourceLabel(sourceId))
-          .join(', ')}`
-      };
-      return;
-    }
-
     try {
       const result = CodingSchemeFactory.deriveValue(
         variableCodings,
@@ -486,6 +479,14 @@ export class EditSourceParametersDialog {
           message: `${this.tr('derive-processing.solver-test.result')}: ${
             EditSourceParametersDialog.formatSolverTestValue(result.value)
           }`
+        };
+        return;
+      }
+
+      if (result.status === 'CODING_INCOMPLETE') {
+        this.solverTestResult = {
+          type: 'warning',
+          message: this.tr('derive-processing.solver-test.incomplete')
         };
         return;
       }
@@ -572,12 +573,29 @@ export class EditSourceParametersDialog {
         .filter(coding => Boolean(coding.alias))
         .map(coding => [coding.alias as string, coding.id])
     );
-    const references = Array.from(expression.matchAll(/\$\{(\s*[\w,-]+\s*)}/g))
-      .map(match => match[1].trim())
+    const references = Array.from(expression.matchAll(/\$\{([^{}]+)}/g))
+      .map(match => EditSourceParametersDialog.getSolverVariableName(match[1]))
+      .filter((variableName): variableName is string => Boolean(variableName))
       .map(variableName => variableIdsByAlias.get(variableName) ||
         variableName);
 
     return [...new Set(references)];
+  }
+
+  private static getSolverVariableName(tokenContent: string): string | null {
+    let variableName = tokenContent.split(':', 1)[0].trim();
+
+    if (variableName.endsWith(']')) {
+      const fragmentStart = variableName.lastIndexOf('[');
+      if (fragmentStart < 0) return null;
+
+      const fragmentIndex = variableName.slice(fragmentStart + 1, -1).trim();
+      if (!/^\d+$/.test(fragmentIndex)) return null;
+
+      variableName = variableName.slice(0, fragmentStart).trim();
+    }
+
+    return /^[a-zA-Z0-9_,-]+$/.test(variableName) ? variableName : null;
   }
 
   private getSourceLabel(sourceId: string): string {

--- a/src/assets/de.json
+++ b/src/assets/de.json
@@ -122,13 +122,16 @@
     },
     "solver-help": {
       "title": "Syntaxhilfe für Solver-Ausdrücke",
-      "description": "Solver-Ausdrücke werden mit math.js ausgewertet. Verwenden Sie Zahlen, Rechenzeichen und math.js-Funktionen; Quellvariablen referenzieren Sie mit ${Variablenname} oder ${VariablenID}.",
+      "description": "Solver-Ausdrücke werden mit math.js ausgewertet. Quellvariablen referenzieren Sie mit ${Variablenname}; ${VAR[0]} greift auf das erste Fragment zu (Indizes beginnen bei 0).",
+      "policies": "Optional folgen Policies für leere/fehlende und nichtnumerische Werte: ${VAR[i]:Leer-Policy:Nichtnumerisch-Policy}. Erlaubt sind ERROR, INC oder ein numerischer Defaultwert.",
+      "fragment-mismatch": "Passt der Wert nicht auf die Fragmentierungs-Regex, gilt das Fragment als fehlend und die erste Policy wird verwendet.",
       "examples-title": "Beispiele:",
       "examples": {
         "arithmetic": "einfache Rechenoperationen",
         "variables": "Werte aus zwei Quellvariablen addieren",
         "function": "Prozentwert berechnen und runden",
-        "condition": "Bedingung: Ergebnis ist 1, wenn Punkte mindestens 5 sind, sonst 0"
+        "condition": "Bedingung: Ergebnis ist 1, wenn Punkte mindestens 5 sind, sonst 0",
+        "fragment-policies": "Bruchfragmente verwenden; fehlende oder nichtnumerische Fragmente ergeben CODING_INCOMPLETE"
       },
       "docs-link": "math.js-Syntax öffnen"
     }

--- a/src/assets/en.json
+++ b/src/assets/en.json
@@ -35,13 +35,16 @@
     },
     "solver-help": {
       "title": "Syntax help for solver expressions",
-      "description": "Solver expressions are evaluated with math.js. Use numbers, operators and math.js functions; refer to source variables with ${VariableName} or ${VariableID}.",
+      "description": "Solver expressions are evaluated with math.js. Refer to source variables with ${VariableName}; ${VAR[0]} accesses the first fragment (indices start at 0).",
+      "policies": "Optionally append policies for empty/missing and non-numeric values: ${VAR[i]:emptyPolicy:nonNumericPolicy}. Allowed values are ERROR, INC, or a numeric default.",
+      "fragment-mismatch": "If the value does not match the fragmenting regular expression, the fragment is treated as missing and the first policy is applied.",
       "examples-title": "Examples:",
       "examples": {
         "arithmetic": "simple arithmetic",
         "variables": "add values from two source variables",
         "function": "calculate and round a percentage",
-        "condition": "condition: result is 1 when points are at least 5, otherwise 0"
+        "condition": "condition: result is 1 when points are at least 5, otherwise 0",
+        "fragment-policies": "use fraction fragments; missing or non-numeric fragments produce CODING_INCOMPLETE"
       },
       "docs-link": "Open math.js syntax"
     }


### PR DESCRIPTION
## Summary

- recognize solver references with fragment indices and empty/non-numeric policies
- delegate raw and fragmented value handling to `deriveValue()`
- display `CODING_INCOMPLETE` as a controlled `INC` result
- document zero-based fragments, policy syntax, and regex mismatch behavior
- cover source detection, fragment evaluation, mismatch handling, and localized help text with tests

## Root cause

The Schemer dialog only recognized simple `${VAR}` references and prevalidated complete raw values as numeric. This bypassed fragment and policy semantics and caused controlled incomplete results to appear as generic evaluation errors.

## Validation

- full test suite: 335 component tests and 6 Schemer tests
- targeted solver dialog suite: 27 tests
- ESLint
- JSON parsing and `git diff --check`

Related to #141