### PR TITLE
Extend solver help and fragment source insertion

### DIFF
--- a/projects/ngx-coding-components/src/lib/translations/de.json
+++ b/projects/ngx-coding-components/src/lib/translations/de.json
@@ -294,12 +294,15 @@
     "solver-help": {
       "title": "Syntaxhilfe für Solver-Ausdrücke",
       "description": "Solver-Ausdrücke werden mit math.js ausgewertet. Verwenden Sie Zahlen, Rechenzeichen und math.js-Funktionen; Quellvariablen referenzieren Sie mit ${Variablenname} oder ${VariablenID}.",
+      "policy-description": "Optional kann ein Fragmentindex sowie das Verhalten bei leeren und nicht-numerischen Werten angegeben werden. Mögliche Regeln sind INC, ERROR oder ein numerischer Ersatzwert; ohne Angabe gilt ERROR.",
       "examples-title": "Beispiele:",
       "examples": {
         "arithmetic": "einfache Rechenoperationen",
         "variables": "Werte aus zwei Quellvariablen addieren",
         "function": "Prozentwert berechnen und runden",
-        "condition": "Bedingung: Ergebnis ist 1, wenn Punkte mindestens 5 sind, sonst 0"
+        "condition": "Bedingung: Ergebnis ist 1, wenn Punkte mindestens 5 sind, sonst 0",
+        "fragment": "Zähler (Fragment 0) eines Bruchs verwenden; bei leerem Wert unvollständig, bei nicht-numerischem Wert Fehler (entspricht ${Bruch[0]:INC:ERROR})",
+        "policies": "Summand verwenden; leeren Wert durch 0 ersetzen, bei nicht-numerischem Wert unvollständig"
       },
       "docs-link": "math.js-Syntax öffnen"
     }

--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.html
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.html
@@ -59,13 +59,18 @@
       </mat-form-field>
 
       <mat-menu #solverSourceMenu="matMenu">
-        @for (source of selectedSolverSources; track source.id) {
+        @for (source of solverSourceReferences; track getSolverSourceReference(source)) {
           <button class="solver-source-menu__item"
                   mat-menu-item
                   type="button"
                   (click)="insertSolverSourceReference(source, solverExpressionInput)">
             <mat-icon>input</mat-icon>
-            <span>{{ source.label }}</span>
+            <span>
+              {{ source.label }}
+              @if (source.fragmentIndex !== undefined) {
+                [{{ source.fragmentIndex }}]
+              }
+            </span>
             <code class="solver-source-menu__reference">
               {{ getSolverSourceReference(source) }}
             </code>

--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.html
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.html
@@ -125,6 +125,11 @@
           </span>
         </div>
         <p>{{ 'derive-processing.solver-help.description' | translate }}</p>
+        <p>
+          <code>{{ solverPolicySyntax }}</code>
+          -
+          {{ 'derive-processing.solver-help.policy-description' | translate }}
+        </p>
         <div>{{ 'derive-processing.solver-help.examples-title' | translate }}</div>
         <ul>
           @for (example of solverExpressionExamples; track example.expression) {

--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.spec.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.spec.ts
@@ -558,12 +558,14 @@ describe('EditSourceParametersDialog', () => {
         `${emptyPolicy.token}:${nonNumericPolicy.token}`;
 
       it(`should apply whole-value empty policies (${policyLabel})`, () => {
-        const dialog = createPolicyDialog(
-          `V1:${referencePolicies}`,
-          ''
-        );
+        ['', '   '].forEach(testValue => {
+          const dialog = createPolicyDialog(
+            `V1:${referencePolicies}`,
+            testValue
+          );
 
-        expectSolverOutcome(dialog, emptyPolicy.outcome);
+          expectSolverOutcome(dialog, emptyPolicy.outcome);
+        });
       });
 
       it(`should apply whole-value non-numeric policies (${policyLabel})`, () => {

--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.spec.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.spec.ts
@@ -7,6 +7,11 @@ import { SchemerService } from '../../services/schemer.service';
 
 describe('EditSourceParametersDialog', () => {
   const solverRef = (variableName: string): string => `\${${variableName}}`;
+  const solverPolicies = [
+    { token: 'ERROR', outcome: 'error' },
+    { token: 'INC', outcome: 'incomplete' },
+    { token: '5', outcome: 'success' }
+  ] as const;
 
   const translations: Record<string, string> = {
     'derive-processing.solver-test.result': 'Ergebnis',
@@ -73,6 +78,66 @@ describe('EditSourceParametersDialog', () => {
       schemerService,
       translateService
     );
+  };
+
+  const expectSolverOutcome = (
+    dialog: EditSourceParametersDialog,
+    outcome: 'success' | 'incomplete' | 'error' | 'invalid',
+    successValue = '5'
+  ): void => {
+    dialog.runSolverTest();
+
+    if (outcome === 'success') {
+      expect(dialog.solverTestResult).toEqual({
+        type: 'success',
+        message: `Ergebnis: ${successValue}`
+      });
+      return;
+    }
+
+    if (outcome === 'incomplete') {
+      expect(dialog.solverTestResult).toEqual({
+        type: 'incomplete',
+        message: 'Ergebnis: Kodierung unvollständig'
+      });
+      return;
+    }
+
+    expect(dialog.solverTestResult?.type).toBe('error');
+    if (outcome === 'invalid') {
+      expect(dialog.solverTestResult?.message).toContain(
+        'Bitte numerischen Testwert prüfen'
+      );
+    } else {
+      expect(dialog.solverTestResult?.message).toBe(
+        'Der Ausdruck konnte nicht ausgewertet werden.'
+      );
+    }
+  };
+
+  const createPolicyDialog = (
+    reference: string,
+    testValue: string,
+    fragmenting?: string
+  ): EditSourceParametersDialog => {
+    const dialog = createDialog({
+      selfAlias: 'D',
+      sourceType: 'SOLVER',
+      sourceParameters: { solverExpression: solverRef(reference) },
+      deriveSources: ['v1'],
+      codingScheme: {
+        variableCodings: [
+          {
+            id: 'v1',
+            alias: 'V1',
+            sourceType: 'BASE',
+            ...(typeof fragmenting === 'string' ? { fragmenting } : {})
+          }
+        ]
+      }
+    });
+    dialog.solverTestValues['v1'] = testValue;
+    return dialog;
   };
 
   it('should set newVariableMode when selfId is missing', () => {
@@ -392,6 +457,273 @@ describe('EditSourceParametersDialog', () => {
     );
   });
 
+  it('solverSourceReferences should include references for each source fragment', () => {
+    const dialog = createDialog({
+      selfAlias: 'D',
+      sourceType: 'SOLVER',
+      deriveSources: ['v1'],
+      codingScheme: {
+        variableCodings: [
+          {
+            id: 'v1',
+            alias: 'Bruch',
+            sourceType: 'BASE',
+            fragmenting: '^(\\d+)\\s*/\\s*(\\d+)$'
+          }
+        ]
+      }
+    });
+
+    expect(dialog.solverSourceReferences.map(
+      source => dialog.getSolverSourceReference(source)
+    )).toEqual([
+      solverRef('Bruch'),
+      solverRef('Bruch[0]'),
+      solverRef('Bruch[1]')
+    ]);
+  });
+
+  it('solverSourceReferences should ignore invalid fragmenting patterns', () => {
+    const dialog = createDialog({
+      selfAlias: 'D',
+      sourceType: 'SOLVER',
+      deriveSources: ['v1'],
+      codingScheme: {
+        variableCodings: [
+          {
+            id: 'v1',
+            alias: 'V1',
+            sourceType: 'BASE',
+            fragmenting: '('
+          }
+        ]
+      }
+    });
+
+    expect(dialog.solverSourceReferences.map(
+      source => dialog.getSolverSourceReference(source)
+    )).toEqual([solverRef('V1')]);
+  });
+
+  it('solverSourceWarning should recognize fragment and policy references', () => {
+    const dialog = createDialog({
+      selfAlias: 'D',
+      sourceType: 'SOLVER',
+      sourceParameters: {
+        solverExpression: `${solverRef('V1[0]:INC')} + ${solverRef('V2:0:INC')}`
+      },
+      deriveSources: ['v1']
+    });
+
+    expect(dialog.solverSourceWarning).toBe(
+      'Warnung: Im Solver-Ausdruck referenzierte Variable(n) ' +
+      'sind nicht als Quell-Variable(n) ausgewählt: V2'
+    );
+  });
+
+  it('runSolverTest should evaluate fragment references from raw source values', () => {
+    const dialog = createDialog({
+      selfAlias: 'D',
+      sourceType: 'SOLVER',
+      sourceParameters: {
+        solverExpression: solverRef('Bruch[0]:INC')
+      },
+      deriveSources: ['v1'],
+      codingScheme: {
+        variableCodings: [
+          {
+            id: 'v1',
+            alias: 'Bruch',
+            sourceType: 'BASE',
+            fragmenting: '^(\\d+)\\s*/\\s*(\\d+)$'
+          }
+        ]
+      }
+    });
+
+    dialog.solverTestValues['v1'] = '1/2';
+    dialog.runSolverTest();
+
+    expect(dialog.solverTestResult).toEqual({
+      type: 'success',
+      message: 'Ergebnis: 1'
+    });
+  });
+
+  solverPolicies.forEach(emptyPolicy => {
+    solverPolicies.forEach(nonNumericPolicy => {
+      const policyLabel =
+        `empty=${emptyPolicy.token}, nonNumeric=${nonNumericPolicy.token}`;
+      const referencePolicies =
+        `${emptyPolicy.token}:${nonNumericPolicy.token}`;
+
+      it(`should apply whole-value empty policies (${policyLabel})`, () => {
+        const dialog = createPolicyDialog(
+          `V1:${referencePolicies}`,
+          ''
+        );
+
+        expectSolverOutcome(dialog, emptyPolicy.outcome);
+      });
+
+      it(`should apply whole-value non-numeric policies (${policyLabel})`, () => {
+        const dialog = createPolicyDialog(
+          `V1:${referencePolicies}`,
+          'abc'
+        );
+        const expectedOutcome = nonNumericPolicy.token === 'ERROR' ?
+          'invalid' :
+          nonNumericPolicy.outcome;
+
+        expectSolverOutcome(dialog, expectedOutcome);
+      });
+
+      it(`should preserve whole numeric values (${policyLabel})`, () => {
+        const dialog = createPolicyDialog(
+          `V1:${referencePolicies}`,
+          '7'
+        );
+
+        expectSolverOutcome(dialog, 'success', '7');
+      });
+
+      it(`should apply fragment empty policies (${policyLabel})`, () => {
+        const dialog = createPolicyDialog(
+          `V1[0]:${referencePolicies}`,
+          '',
+          '^(.*)$'
+        );
+
+        expectSolverOutcome(dialog, emptyPolicy.outcome);
+      });
+
+      it(`should apply fragment non-numeric policies (${policyLabel})`, () => {
+        const dialog = createPolicyDialog(
+          `V1[0]:${referencePolicies}`,
+          'abc',
+          '^(.*)$'
+        );
+
+        expectSolverOutcome(dialog, nonNumericPolicy.outcome);
+      });
+
+      it(`should preserve numeric fragment values (${policyLabel})`, () => {
+        const dialog = createPolicyDialog(
+          `V1[0]:${referencePolicies}`,
+          '7',
+          '^(.*)$'
+        );
+
+        expectSolverOutcome(dialog, 'success', '7');
+      });
+
+      it(`should apply empty policies to missing fragments (${policyLabel})`, () => {
+        const dialog = createPolicyDialog(
+          `V1[1]:${referencePolicies}`,
+          '7',
+          '^(\\d+)$'
+        );
+
+        expectSolverOutcome(dialog, emptyPolicy.outcome);
+      });
+    });
+  });
+
+  it('runSolverTest should support the shorthand empty policy syntax', () => {
+    const defaultError = createPolicyDialog('V1:ERROR', '');
+    expectSolverOutcome(defaultError, 'error');
+
+    const incomplete = createPolicyDialog('V1:INC', '');
+    expectSolverOutcome(incomplete, 'incomplete');
+
+    const replacement = createPolicyDialog('V1:5', '');
+    expectSolverOutcome(replacement, 'success');
+  });
+
+  it('runSolverTest should resolve ID and alias references together', () => {
+    const dialog = createDialog({
+      selfAlias: 'D',
+      sourceType: 'SOLVER',
+      sourceParameters: {
+        solverExpression:
+          `${solverRef('First[1]:ERROR:ERROR')} + ` +
+          `${solverRef('v2:ERROR:4')}`
+      },
+      deriveSources: ['v1', 'v2'],
+      codingScheme: {
+        variableCodings: [
+          {
+            id: 'v1',
+            alias: 'First',
+            sourceType: 'BASE',
+            fragmenting: '^([A-Z]+)-(\\d+)$'
+          },
+          {
+            id: 'v2',
+            alias: 'Second',
+            sourceType: 'BASE'
+          }
+        ]
+      }
+    });
+
+    dialog.solverTestValues['v1'] = 'ABC-12';
+    dialog.solverTestValues['v2'] = 'abc';
+
+    expectSolverOutcome(dialog, 'success', '16');
+  });
+
+  it('runSolverTest should handle whole and fragment references to one source', () => {
+    const dialog = createDialog({
+      selfAlias: 'D',
+      sourceType: 'SOLVER',
+      sourceParameters: {
+        solverExpression:
+          `${solverRef('V1[0]:ERROR:ERROR')} + ` +
+          `${solverRef('V1:ERROR:5')}`
+      },
+      deriveSources: ['v1'],
+      codingScheme: {
+        variableCodings: [
+          {
+            id: 'v1',
+            alias: 'V1',
+            sourceType: 'BASE',
+            fragmenting: '^(\\d+)$'
+          }
+        ]
+      }
+    });
+    dialog.solverTestValues['v1'] = '7';
+
+    expectSolverOutcome(dialog, 'success', '14');
+  });
+
+  it('solverSourceReferences should ignore non-capturing regex groups', () => {
+    const dialog = createDialog({
+      selfAlias: 'D',
+      sourceType: 'SOLVER',
+      deriveSources: ['v1'],
+      codingScheme: {
+        variableCodings: [
+          {
+            id: 'v1',
+            alias: 'V1',
+            sourceType: 'BASE',
+            fragmenting: '^(?:prefix-)(\\d+)$'
+          }
+        ]
+      }
+    });
+
+    expect(dialog.solverSourceReferences.map(
+      source => dialog.getSolverSourceReference(source)
+    )).toEqual([
+      solverRef('V1'),
+      solverRef('V1[0]')
+    ]);
+  });
+
   it('runSolverTest should report non-numeric test values', () => {
     const dialog = createDialog({
       selfAlias: 'D',
@@ -425,6 +757,12 @@ describe('EditSourceParametersDialog', () => {
       type: 'success',
       message: 'Ergebnis: 0'
     });
+  });
+
+  it('runSolverTest should treat whitespace-only values as empty', () => {
+    const dialog = createPolicyDialog('V1:0:ERROR', '   ');
+
+    expectSolverOutcome(dialog, 'success', '0');
   });
 
   it('runSolverTest should apply a non-numeric-value policy', () => {
@@ -554,5 +892,10 @@ describe('EditSourceParametersDialog', () => {
     expect(expressions.some(
       expression => expression.includes('?') && expression.includes(':')
     )).toBeTrue();
+    expect(dialog.solverPolicySyntax).toBe(
+      solverRef('VAR[i]:emptyPolicy:nonNumericPolicy')
+    );
+    expect(expressions).toContain(solverRef('Bruch[0]:INC'));
+    expect(expressions).toContain(solverRef('Summand:0:INC'));
   });
 });

--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.ts
@@ -244,6 +244,9 @@ export class EditSourceParametersDialog {
   readonly solverExpressionDocsUrl =
     'https://mathjs.org/docs/expressions/syntax.html';
 
+  readonly solverPolicySyntax =
+    `${SOLVER_VARIABLE_PREFIX}{VAR[i]:emptyPolicy:nonNumericPolicy}`;
+
   readonly solverExpressionExamples: SolverExpressionExample[] = [
     {
       expression: '1 + 2 * 3',
@@ -261,6 +264,14 @@ export class EditSourceParametersDialog {
     {
       expression: `${SOLVER_VARIABLE_PREFIX}{Punkte} >= 5 ? 1 : 0`,
       descriptionKey: 'derive-processing.solver-help.examples.condition'
+    },
+    {
+      expression: `${SOLVER_VARIABLE_PREFIX}{Bruch[0]:INC}`,
+      descriptionKey: 'derive-processing.solver-help.examples.fragment'
+    },
+    {
+      expression: `${SOLVER_VARIABLE_PREFIX}{Summand:0:INC}`,
+      descriptionKey: 'derive-processing.solver-help.examples.policies'
     }
   ];
 

--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.ts
@@ -54,6 +54,12 @@ interface SolverExpressionExample {
   descriptionKey: string;
 }
 
+interface SolverSourceReference {
+  id: string;
+  label: string;
+  fragmentIndex?: number;
+}
+
 interface SolverVariableReference {
   sourceId: string;
   hasFragmentIndex: boolean;
@@ -325,6 +331,18 @@ export class EditSourceParametersDialog {
     }));
   }
 
+  get solverSourceReferences(): SolverSourceReference[] {
+    return this.selectedSolverSources.flatMap(source => {
+      const fragmentReferences = this.getSourceFragmentIndexes(source.id)
+        .map(fragmentIndex => ({
+          ...source,
+          fragmentIndex
+        }));
+
+      return [source, ...fragmentReferences];
+    });
+  }
+
   get solverSourceWarning(): string | null {
     const missingSourceLabels = this.getMissingSolverSourceIds()
       .map(sourceId => this.getSourceLabel(sourceId));
@@ -413,11 +431,12 @@ export class EditSourceParametersDialog {
   }
 
   insertSolverSourceReference(
-    source: { id: string; label: string },
+    source: SolverSourceReference,
     input: HTMLInputElement
   ): void {
     const reference = this.getSolverVariableReference(
-      source.label || source.id
+      source.label || source.id,
+      source.fragmentIndex
     );
     const expression = this.data.sourceParameters.solverExpression || '';
     const selectionStart = input.selectionStart ?? expression.length;
@@ -437,8 +456,11 @@ export class EditSourceParametersDialog {
     });
   }
 
-  getSolverSourceReference(source: { id: string; label: string }): string {
-    return this.getSolverVariableReference(source.label || source.id);
+  getSolverSourceReference(source: SolverSourceReference): string {
+    return this.getSolverVariableReference(
+      source.label || source.id,
+      source.fragmentIndex
+    );
   }
 
   clearSolverTestResult(): void {
@@ -733,8 +755,30 @@ export class EditSourceParametersDialog {
     return JSON.stringify(value) || '';
   }
 
-  private getSolverVariableReference(variableName: string): string {
-    return `${this.solverVariablePrefix}{${variableName}}`;
+  private getSourceFragmentIndexes(sourceId: string): number[] {
+    const sourceCoding = this.schemerService.codingScheme?.variableCodings
+      .find(coding => coding.id === sourceId);
+    const fragmenting = sourceCoding?.fragmenting;
+
+    if (!fragmenting) return [];
+
+    try {
+      const emptyAlternativeMatch = new RegExp(`(?:${fragmenting})|`).exec('');
+      const fragmentCount = (emptyAlternativeMatch?.length || 1) - 1;
+      return Array.from({ length: fragmentCount }, (_, index) => index);
+    } catch {
+      return [];
+    }
+  }
+
+  private getSolverVariableReference(
+    variableName: string,
+    fragmentIndex?: number
+  ): string {
+    const fragmentSuffix = typeof fragmentIndex === 'number' ?
+      `[${fragmentIndex}]` :
+      '';
+    return `${this.solverVariablePrefix}{${variableName}${fragmentSuffix}}`;
   }
 
   private setSolverTestError(translationKey: string): void {

--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.ts
@@ -659,11 +659,10 @@ export class EditSourceParametersDialog {
     if (reference.hasFragmentIndex) return false;
 
     const value = this.solverTestValues[reference.sourceId] || '';
+    if (!value.trim()) return false;
     if (CodingFactory.getValueAsNumber(value) !== null) return false;
 
-    const policy = value.trim() ?
-      reference.nonNumericPolicy :
-      reference.emptyPolicy;
+    const policy = reference.nonNumericPolicy;
     if (typeof policy === 'undefined') return true;
 
     const trimmedPolicy = policy.trim();

--- a/src/assets/de.json
+++ b/src/assets/de.json
@@ -123,12 +123,15 @@
     "solver-help": {
       "title": "Syntaxhilfe für Solver-Ausdrücke",
       "description": "Solver-Ausdrücke werden mit math.js ausgewertet. Verwenden Sie Zahlen, Rechenzeichen und math.js-Funktionen; Quellvariablen referenzieren Sie mit ${Variablenname} oder ${VariablenID}.",
+      "policy-description": "Optional kann ein Fragmentindex sowie das Verhalten bei leeren und nicht-numerischen Werten angegeben werden. Mögliche Regeln sind INC, ERROR oder ein numerischer Ersatzwert; ohne Angabe gilt ERROR.",
       "examples-title": "Beispiele:",
       "examples": {
         "arithmetic": "einfache Rechenoperationen",
         "variables": "Werte aus zwei Quellvariablen addieren",
         "function": "Prozentwert berechnen und runden",
-        "condition": "Bedingung: Ergebnis ist 1, wenn Punkte mindestens 5 sind, sonst 0"
+        "condition": "Bedingung: Ergebnis ist 1, wenn Punkte mindestens 5 sind, sonst 0",
+        "fragment": "Zähler (Fragment 0) eines Bruchs verwenden; bei leerem Wert unvollständig, bei nicht-numerischem Wert Fehler (entspricht ${Bruch[0]:INC:ERROR})",
+        "policies": "Summand verwenden; leeren Wert durch 0 ersetzen, bei nicht-numerischem Wert unvollständig"
       },
       "docs-link": "math.js-Syntax öffnen"
     }

--- a/src/assets/en.json
+++ b/src/assets/en.json
@@ -36,12 +36,15 @@
     "solver-help": {
       "title": "Syntax help for solver expressions",
       "description": "Solver expressions are evaluated with math.js. Use numbers, operators and math.js functions; refer to source variables with ${VariableName} or ${VariableID}.",
+      "policy-description": "Optionally specify a fragment index and how empty or non-numeric values are handled. Available policies are INC, ERROR, or a numeric replacement value; ERROR is the default.",
       "examples-title": "Examples:",
       "examples": {
         "arithmetic": "simple arithmetic",
         "variables": "add values from two source variables",
         "function": "calculate and round a percentage",
-        "condition": "condition: result is 1 when points are at least 5, otherwise 0"
+        "condition": "condition: result is 1 when points are at least 5, otherwise 0",
+        "fragment": "use the numerator (fragment 0) of a fraction; mark empty values incomplete and non-numeric values as errors (equivalent to ${Bruch[0]:INC:ERROR})",
+        "policies": "use a summand; replace empty values with 0 and mark non-numeric values incomplete"
       },
       "docs-link": "Open math.js syntax"
     }


### PR DESCRIPTION
## Summary

- document the extended solver syntax `${VAR[i]:emptyPolicy:nonNumericPolicy}` with the requested examples
- offer fragment references such as `${I02_FRAG[0]}` and `${I02_FRAG[1]}` in the source insertion menu
- keep the current fragment- and policy-aware solver validation from `master`
- preserve `CODING_INCOMPLETE` results for `INC` policies in the interactive solver test
- cover whole values, fragments, missing indices, aliases, IDs, mixed sources, and whitespace-only empty values
- handle empty strings and whitespace-only whole values consistently in the interactive solver test

This addresses the follow-up feedback in #163.

## Validation

- `npm run test:cc` — 414 tests passed
- focused solver dialog suite — 100 tests passed; the whole-value policy matrix now checks both `''` and `'   '` for every empty/non-numeric policy combination
- ESLint passed for the changed TypeScript files
- `npx ng build ngx-coding-components`
- exhaustive visible-browser Playwright UI matrix — 84 cases covering syntax help, selected/unselected source warnings, fragment insertion, whole-value policies, fragment policies, missing/non-numeric/numeric values, and `INC` shorthand
- follow-up visible-browser verification after the whitespace fix — 6/6 cases passed:
  - empty and whitespace-only values produce the same generic evaluation error for `emptyPolicy=ERROR`
  - verified with non-numeric policies `ERROR`, `INC`, and numeric fallback `5`
  - all results used the expected error styling
  - no browser console or page errors
