### PR TITLE
Handle qualified solver source references

### DIFF
--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.html
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.html
@@ -110,6 +110,7 @@
         @if (solverTestResult) {
           <div class="solver-test-result"
                [class.solver-test-result-ok]="solverTestResult.type === 'success'"
+               [class.solver-test-result-incomplete]="solverTestResult.type === 'incomplete'"
                [class.solver-test-result-error]="solverTestResult.type === 'error'">
             {{ solverTestResult.message }}
           </div>

--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.spec.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.spec.ts
@@ -289,6 +289,32 @@ describe('EditSourceParametersDialog', () => {
     expect(dialog.solverSourceWarning).toContain('V2');
   });
 
+  it('solverSourceWarning should recognize indexed and policy-qualified references', () => {
+    [
+      solverRef('V2[0]'),
+      solverRef('V2:0'),
+      solverRef('V2[1]:INC:0')
+    ].forEach(solverExpression => {
+      const dialog = createDialog({
+        selfAlias: 'D',
+        sourceType: 'SOLVER',
+        sourceParameters: { solverExpression },
+        deriveSources: ['v1']
+      });
+
+      expect(dialog.solverSourceWarning).toContain('V2');
+
+      const selectedDialog = createDialog({
+        selfAlias: 'D',
+        sourceType: 'SOLVER',
+        sourceParameters: { solverExpression },
+        deriveSources: ['v2']
+      });
+
+      expect(selectedDialog.solverSourceWarning).toBeNull();
+    });
+  });
+
   it('solverSourceWarning should update when expression or source selection changes', () => {
     const dialog = createDialog({
       selfAlias: 'D',
@@ -381,6 +407,67 @@ describe('EditSourceParametersDialog', () => {
       'Bitte numerischen Testwert prüfen'
     );
     expect(dialog.solverTestResult?.message).toContain('V1');
+  });
+
+  it('runSolverTest should apply an empty-value policy', () => {
+    const dialog = createDialog({
+      selfAlias: 'D',
+      sourceType: 'SOLVER',
+      sourceParameters: { solverExpression: solverRef('V1:0') },
+      deriveSources: ['v1']
+    });
+
+    dialog.solverTestValues['v1'] = '';
+    dialog.runSolverTest();
+
+    expect(dialog.solverTestResult).toEqual({
+      type: 'success',
+      message: 'Ergebnis: 0'
+    });
+  });
+
+  it('runSolverTest should apply a non-numeric-value policy', () => {
+    const dialog = createDialog({
+      selfAlias: 'D',
+      sourceType: 'SOLVER',
+      sourceParameters: { solverExpression: solverRef('V1:ERROR:5') },
+      deriveSources: ['v1']
+    });
+
+    dialog.solverTestValues['v1'] = 'abc';
+    dialog.runSolverTest();
+
+    expect(dialog.solverTestResult).toEqual({
+      type: 'success',
+      message: 'Ergebnis: 5'
+    });
+  });
+
+  it('runSolverTest should evaluate a numeric fragment from a raw value', () => {
+    const dialog = createDialog({
+      selfAlias: 'D',
+      sourceType: 'SOLVER',
+      sourceParameters: { solverExpression: solverRef('V1[1]') },
+      deriveSources: ['v1'],
+      codingScheme: {
+        variableCodings: [
+          {
+            id: 'v1',
+            alias: 'V1',
+            sourceType: 'BASE',
+            fragmenting: '([A-Za-z]+)-(\\d+)'
+          }
+        ]
+      }
+    });
+
+    dialog.solverTestValues['v1'] = 'ABC-7';
+    dialog.runSolverTest();
+
+    expect(dialog.solverTestResult).toEqual({
+      type: 'success',
+      message: 'Ergebnis: 7'
+    });
   });
 
   it('runSolverTest should report syntax and evaluation errors', () => {

--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.spec.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.spec.ts
@@ -10,6 +10,7 @@ describe('EditSourceParametersDialog', () => {
 
   const translations: Record<string, string> = {
     'derive-processing.solver-test.result': 'Ergebnis',
+    'status-label.CODING_INCOMPLETE': 'Kodierung unvollständig',
     'derive-processing.solver-test.error-expression-missing': 'Bitte einen Solver-Ausdruck eingeben.',
     'derive-processing.solver-test.error-sources-missing': 'Bitte mindestens eine Quellvariable auswählen.',
     'derive-processing.solver-test.error-unselected-source': 'Der Ausdruck verweist auf nicht ausgewählte Quelle(n)',
@@ -440,6 +441,40 @@ describe('EditSourceParametersDialog', () => {
     expect(dialog.solverTestResult).toEqual({
       type: 'success',
       message: 'Ergebnis: 5'
+    });
+  });
+
+  it('runSolverTest should report an incomplete result for an empty-value INC policy', () => {
+    const dialog = createDialog({
+      selfAlias: 'D',
+      sourceType: 'SOLVER',
+      sourceParameters: { solverExpression: solverRef('V1:INC') },
+      deriveSources: ['v1']
+    });
+
+    dialog.solverTestValues['v1'] = '';
+    dialog.runSolverTest();
+
+    expect(dialog.solverTestResult).toEqual({
+      type: 'incomplete',
+      message: 'Ergebnis: Kodierung unvollständig'
+    });
+  });
+
+  it('runSolverTest should report an incomplete result for a non-numeric-value INC policy', () => {
+    const dialog = createDialog({
+      selfAlias: 'D',
+      sourceType: 'SOLVER',
+      sourceParameters: { solverExpression: solverRef('V1:ERROR:INC') },
+      deriveSources: ['v1']
+    });
+
+    dialog.solverTestValues['v1'] = 'abc';
+    dialog.runSolverTest();
+
+    expect(dialog.solverTestResult).toEqual({
+      type: 'incomplete',
+      message: 'Ergebnis: Kodierung unvollständig'
     });
   });
 

--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.ts
@@ -45,7 +45,7 @@ export interface EditSourceParametersDialogData {
 }
 
 type SolverTestResult = {
-  type: 'success' | 'error';
+  type: 'success' | 'incomplete' | 'error';
   message: string;
 };
 
@@ -194,6 +194,11 @@ const SOLVER_VARIABLE_REFERENCE_PATTERN =
     .solver-test-result-ok {
       background: #e8f5e9;
       color: #1b5e20;
+    }
+
+    .solver-test-result-incomplete {
+      background: #fff8e1;
+      color: #5f3f00;
     }
 
     .solver-test-result-error {
@@ -499,6 +504,16 @@ export class EditSourceParametersDialog {
           message: `${this.tr('derive-processing.solver-test.result')}: ${
             EditSourceParametersDialog.formatSolverTestValue(result.value)
           }`
+        };
+        return;
+      }
+
+      if (result.status === 'CODING_INCOMPLETE') {
+        this.solverTestResult = {
+          type: 'incomplete',
+          message: `${this.tr(
+            'derive-processing.solver-test.result'
+          )}: ${this.tr('status-label.CODING_INCOMPLETE')}`
         };
         return;
       }

--- a/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.ts
+++ b/projects/ngx-coding-components/src/lib/var-coding/dialogs/edit-source-parameters-dialog.component.ts
@@ -54,7 +54,16 @@ interface SolverExpressionExample {
   descriptionKey: string;
 }
 
+interface SolverVariableReference {
+  sourceId: string;
+  hasFragmentIndex: boolean;
+  emptyPolicy?: string;
+  nonNumericPolicy?: string;
+}
+
 const SOLVER_VARIABLE_PREFIX = '$';
+const SOLVER_VARIABLE_REFERENCE_PATTERN =
+  /\$\{\s*([\w,-]+)(?:\s*\[\s*(\d+)\s*])?(?:\s*:([^}:]*))?(?:\s*:([^}:]*))?\s*}/g;
 
 @Component({
   templateUrl: 'edit-source-parameters-dialog.component.html',
@@ -439,10 +448,12 @@ export class EditSourceParametersDialog {
     }
 
     const variableCodings = this.getVariableCodingsForSolverTest();
-    const referencedVariables = EditSourceParametersDialog.getReferencedSolverVariables(
+    const solverReferences = EditSourceParametersDialog.getSolverReferences(
       expression,
       variableCodings
     );
+    const referencedVariables = EditSourceParametersDialog
+      .getReferencedSolverVariables(solverReferences);
     const missingSources = this.getMissingSolverSourceIds(referencedVariables);
 
     if (missingSources.length > 0) {
@@ -456,11 +467,13 @@ export class EditSourceParametersDialog {
       return;
     }
 
-    const invalidNumericSources = referencedVariables.filter(
-      sourceId => CodingFactory.getValueAsNumber(
-        this.solverTestValues[sourceId] || ''
-      ) === null
-    );
+    const invalidNumericSources = [
+      ...new Set(
+        solverReferences
+          .filter(reference => this.isInvalidSolverTestValue(reference))
+          .map(reference => reference.sourceId)
+      )
+    ];
 
     if (invalidNumericSources.length > 0) {
       this.solverTestResult = {
@@ -554,8 +567,10 @@ export class EditSourceParametersDialog {
 
     const solverReferences = referencedVariables ||
       EditSourceParametersDialog.getReferencedSolverVariables(
-        expression,
-        this.getVariableCodingsForSolverTest()
+        EditSourceParametersDialog.getSolverReferences(
+          expression,
+          this.getVariableCodingsForSolverTest()
+        )
       );
 
     return solverReferences.filter(
@@ -563,21 +578,49 @@ export class EditSourceParametersDialog {
     );
   }
 
-  private static getReferencedSolverVariables(
+  private static getSolverReferences(
     expression: string,
     variableCodings: VariableCodingData[]
-  ): string[] {
+  ): SolverVariableReference[] {
     const variableIdsByAlias = new Map(
       variableCodings
         .filter(coding => Boolean(coding.alias))
         .map(coding => [coding.alias as string, coding.id])
     );
-    const references = Array.from(expression.matchAll(/\$\{(\s*[\w,-]+\s*)}/g))
-      .map(match => match[1].trim())
-      .map(variableName => variableIdsByAlias.get(variableName) ||
-        variableName);
 
-    return [...new Set(references)];
+    return Array.from(
+      expression.matchAll(SOLVER_VARIABLE_REFERENCE_PATTERN)
+    )
+      .map(match => ({
+        sourceId: variableIdsByAlias.get(match[1]) || match[1],
+        hasFragmentIndex: typeof match[2] !== 'undefined',
+        emptyPolicy: match[3],
+        nonNumericPolicy: match[4]
+      }));
+  }
+
+  private static getReferencedSolverVariables(
+    references: SolverVariableReference[]
+  ): string[] {
+    return [...new Set(references.map(reference => reference.sourceId))];
+  }
+
+  private isInvalidSolverTestValue(
+    reference: SolverVariableReference
+  ): boolean {
+    if (reference.hasFragmentIndex) return false;
+
+    const value = this.solverTestValues[reference.sourceId] || '';
+    if (CodingFactory.getValueAsNumber(value) !== null) return false;
+
+    const policy = value.trim() ?
+      reference.nonNumericPolicy :
+      reference.emptyPolicy;
+    if (typeof policy === 'undefined') return true;
+
+    const trimmedPolicy = policy.trim();
+    return trimmedPolicy.toUpperCase() !== 'INC' &&
+      CodingFactory.getValueAsNumber(trimmedPolicy) === null;
   }
 
   private getSourceLabel(sourceId: string): string {


### PR DESCRIPTION
## Summary

- recognize source variables in direct, indexed, and policy-qualified solver references
- resolve qualified aliases against the selected source-variable IDs
- keep solver test validation aware of fragment access and empty/non-numeric fallback policies
- show `CODING_INCOMPLETE` from `INC` policies as an expected, visually distinct solver-test result
- add regression coverage for warnings, selected sources, fallback policies, fragmented values, and incomplete results

## Root cause

The warning used a regular expression that only accepted references whose contents consisted entirely of the variable name. References such as `${VAR[0]}` and `${VAR:0}` were therefore skipped. Because the same reference extraction is used by the interactive solver test, the extended parser also retains fragment and policy metadata so valid fallback values and fragmented raw inputs are not rejected prematurely.

The test dialog previously treated only `VALUE_CHANGED` as a successful solver outcome. A valid `INC` policy returns `CODING_INCOMPLETE`, which therefore fell through to the generic evaluation error even though evaluation had succeeded.

## User impact

Warnings now identify unselected source variables across the supported solver-reference syntax. Valid indexed references and value policies continue to work in the interactive solver test. `INC` outcomes are displayed as “Ergebnis: Kodierung unvollständig” in a neutral warning style instead of as an evaluation error.

## Validation

- `npm run test:cc` — 342 tests passed
- focused dialog suite — 28 tests passed
- UI matrix — 30/30 combinations passed, including four `INC` variants
- no browser console or page errors
- ESLint on the changed TypeScript files
- `git diff --check`

Fixes #164